### PR TITLE
remove error from StreamHandler.Recv

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Send blocks until the message has been received. When the stream closes the caus
 client from `Err`.
 ```go
 type ClientStream[SendType, RecvType proto.Message] interface {
-	Channel() <-chan *Response[RecvType]
+	Channel() <-chan RecvType
 	Send(msg SendType, opts ...StreamOption) error
 	Close(cause error) error
 	Err() error

--- a/client.go
+++ b/client.go
@@ -469,7 +469,7 @@ func OpenStream[SendType, RecvType proto.Message](
 			rpc:   rpc,
 			topic: topic,
 		},
-		recvChan: make(chan *Response[RecvType], c.channelSize),
+		recvChan: make(chan RecvType, c.channelSize),
 		streamID: streamID,
 		acks:     map[string]chan struct{}{requestID: ackChan},
 	}

--- a/interceptors.go
+++ b/interceptors.go
@@ -20,7 +20,7 @@ type ClientRequestHook func(ctx context.Context, req proto.Message, info RPCInfo
 type ClientResponseHook func(ctx context.Context, req proto.Message, info RPCInfo, resp proto.Message, err error)
 
 type StreamHandler interface {
-	Recv(msg proto.Message, err error) error
+	Recv(msg proto.Message) error
 	Send(msg proto.Message, opts ...StreamOption) error
 	Close(cause error) error
 }

--- a/psrpc_test.go
+++ b/psrpc_test.go
@@ -141,16 +141,12 @@ func testStream(t *testing.T, bus MessageBus) {
 		defer close(serverClose)
 
 		for ping := range stream.Channel() {
-			if ping.Err != nil {
-				require.NoError(t, ping.Err)
-			} else {
-				pong := &internal.Response{
-					SentAt: ping.Result.SentAt,
-					Code:   "PONG",
-				}
-				err := stream.Send(pong)
-				require.NoError(t, err)
+			pong := &internal.Response{
+				SentAt: ping.SentAt,
+				Code:   "PONG",
 			}
+			err := stream.Send(pong)
+			require.NoError(t, err)
 		}
 		return nil
 	}
@@ -171,7 +167,7 @@ func testStream(t *testing.T, bus MessageBus) {
 
 		select {
 		case pong := <-stream.Channel():
-			require.Equal(t, "PONG", pong.Result.Code)
+			require.Equal(t, "PONG", pong.Code)
 		case <-time.After(DefaultClientTimeout):
 			t.Fatal("no pong received")
 		}

--- a/server_stream_handler.go
+++ b/server_stream_handler.go
@@ -155,7 +155,7 @@ func (h *streamRPCHandlerImpl[RecvType, SendType]) handleOpenRequest(
 			s:      s,
 			nodeID: open.NodeId,
 		},
-		recvChan: make(chan *Response[RecvType], s.channelSize),
+		recvChan: make(chan RecvType, s.channelSize),
 		streamID: is.StreamId,
 		acks:     map[string]chan struct{}{},
 	}


### PR DESCRIPTION
because we opted to make streams close on errors receive doesn't need to handle them.