### PR TITLE
close server/deregister handler synchronously

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package psrpc
 import (
 	"context"
 	"errors"
+	"io"
 	"sync"
 	"time"
 
@@ -16,7 +17,7 @@ var (
 	ErrRequestCanceled = NewError(Canceled, errors.New("request canceled"))
 	ErrRequestTimedOut = NewError(DeadlineExceeded, errors.New("request timed out"))
 	ErrNoResponse      = NewError(Unavailable, errors.New("no response from servers"))
-	ErrServerGoingAway = NewError(Unavailable, errors.New("server going away"))
+	ErrStreamEOF       = NewError(Unavailable, io.EOF)
 	ErrStreamClosed    = NewError(Canceled, errors.New("stream closed"))
 	ErrSlowConsumer    = NewError(Unavailable, errors.New("stream message discarded by slow consumer"))
 )

--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ var (
 	ErrRequestCanceled = NewError(Canceled, errors.New("request canceled"))
 	ErrRequestTimedOut = NewError(DeadlineExceeded, errors.New("request timed out"))
 	ErrNoResponse      = NewError(Unavailable, errors.New("no response from servers"))
+	ErrServerGoingAway = NewError(Unavailable, errors.New("server going away"))
 	ErrStreamClosed    = NewError(Canceled, errors.New("stream closed"))
 	ErrSlowConsumer    = NewError(Unavailable, errors.New("stream message discarded by slow consumer"))
 )

--- a/helpers.go
+++ b/helpers.go
@@ -65,8 +65,22 @@ func appendChannelParts[T any](buf []byte, parts ...T) []byte {
 	return buf
 }
 
+func channelPartsLen[T any](parts ...T) int {
+	var n int
+	for _, t := range parts {
+		switch v := any(t).(type) {
+		case string:
+			n += len(v) + 1
+		case []string:
+			n += channelPartsLen(v...)
+		}
+	}
+	return n
+}
+
 func formatChannel(parts ...any) string {
-	return string(appendChannelParts(nil, parts...))
+	buf := make([]byte, 0, 4*channelPartsLen(parts...)/3)
+	return string(appendChannelParts(buf, parts...))
 }
 
 func getRPCChannel(serviceName, rpc string, topic []string) string {

--- a/internal/test/service_test.go
+++ b/internal/test/service_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"math/rand"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -109,7 +108,7 @@ func testGeneratedService(t *testing.T, bus psrpc.MessageBus) {
 	require.NoError(t, stream.Close(nil))
 
 	// let the service goroutine run
-	runtime.Gosched()
+	time.Sleep(time.Millisecond * 100)
 
 	sA.Lock()
 	sB.Lock()

--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
+	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -144,11 +145,9 @@ func (s *RPCServer) Close(force bool) {
 	case <-s.shutdown:
 	default:
 		close(s.shutdown)
-		handlers := make([]rpcHandler, 0)
+
 		s.mu.RLock()
-		for _, h := range s.handlers {
-			handlers = append(handlers, h)
-		}
+		handlers := maps.Values(s.handlers)
 		s.mu.RUnlock()
 
 		var wg sync.WaitGroup

--- a/server_stream.go
+++ b/server_stream.go
@@ -252,7 +252,7 @@ func (h *streamRPCHandlerImpl[RecvType, SendType]) close(force bool) {
 			wg.Add(1)
 			s := s
 			go func() {
-				_ = s.Close(ErrServerGoingAway)
+				_ = s.Close(ErrStreamEOF)
 				wg.Done()
 			}()
 		}

--- a/server_stream.go
+++ b/server_stream.go
@@ -27,6 +27,7 @@ type streamRPCHandlerImpl[RecvType, SendType proto.Message] struct {
 	draining     atomic.Bool
 	complete     chan struct{}
 	onCompleted  func()
+	closeOnce    sync.Once
 }
 
 func newStreamRPCHandler[RecvType, SendType proto.Message](

--- a/stream.go
+++ b/stream.go
@@ -70,7 +70,6 @@ func (s *serverStream[RequestType, ResponseType]) close(streamID string) {
 	s.h.mu.Lock()
 	delete(s.h.streams, streamID)
 	s.h.mu.Unlock()
-	s.h.handling.Dec()
 }
 
 type streamInterceptorRoot[SendType, RecvType proto.Message] struct {


### PR DESCRIPTION
there is currently no way to know if a server or handler has shut down which causes bugs when the state thrashes. when this happens it causes  stream registrations to enter unpredictable states and throw errors.