### PR TITLE
 skip waiting for acks after receiving close

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -143,7 +143,6 @@ func (s *streamImpl[SendType, RecvType]) handleStream(is *internal.Stream) error
 			s.err = newErrorFromResponse(b.Close.Code, b.Close.Error)
 			s.mu.Unlock()
 
-			s.waitForPending()
 			s.adapter.close(s.streamID)
 			s.cancelCtx()
 			close(s.recvChan)


### PR DESCRIPTION
close is the last message we're guaranteed to see from a departing stream node so there's no point waiting for anything else. in most cases the sends will time out anyway.