### PR TITLE
prevent closing before publishing ack

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -120,6 +120,9 @@ func (s *streamImpl[SendType, RecvType]) handleStream(is *internal.Stream) error
 			return ErrStreamClosed
 		}
 
+		s.pending.Inc()
+		defer s.pending.Dec()
+
 		v, err := deserializePayload[RecvType](b.Message.RawMessage, b.Message.Message)
 		if err != nil {
 			err = NewError(MalformedRequest, err)


### PR DESCRIPTION
this should fix the flaky test - acks are sent only after messages are successfully enqueued on the stream's output channel - this creates a race between a consuming thread closing the stream and the read loop publishing the ack.