### PR TITLE
timeout unanswered requests quickly

### DIFF
--- a/client.go
+++ b/client.go
@@ -32,6 +32,7 @@ type ClientOption func(*ClientOpts)
 type ClientOpts struct {
 	ClientID             string
 	Timeout              time.Duration
+	SelectionTimeout     time.Duration
 	ChannelSize          int
 	EnableStreams        bool
 	RequestHooks         []ClientRequestHook
@@ -50,6 +51,12 @@ func WithClientID(id string) ClientOption {
 func WithClientTimeout(timeout time.Duration) ClientOption {
 	return func(o *ClientOpts) {
 		o.Timeout = timeout
+	}
+}
+
+func WithClientSelectTimeout(timeout time.Duration) ClientOption {
+	return func(o *ClientOpts) {
+		o.SelectionTimeout = timeout
 	}
 }
 

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -30,8 +30,9 @@ func withStreams() psrpc.ClientOption {
 
 func getClientOpts(opts ...psrpc.ClientOption) psrpc.ClientOpts {
 	o := &psrpc.ClientOpts{
-		Timeout:     psrpc.DefaultClientTimeout,
-		ChannelSize: bus.DefaultChannelSize,
+		Timeout:          psrpc.DefaultClientTimeout,
+		SelectionTimeout: psrpc.DefaultAffinityTimeout,
+		ChannelSize:      bus.DefaultChannelSize,
 	}
 	for _, opt := range opts {
 		opt(o)
@@ -45,11 +46,12 @@ func getRequestOpts(i *info.RequestInfo, options psrpc.ClientOpts, opts ...psrpc
 	}
 	if i.AffinityEnabled {
 		o.SelectionOpts = psrpc.SelectionOpts{
-			AffinityTimeout:     psrpc.DefaultAffinityTimeout,
+			AffinityTimeout:     options.SelectionTimeout,
 			ShortCircuitTimeout: psrpc.DefaultAffinityShortCircuit,
 		}
 	} else {
 		o.SelectionOpts = psrpc.SelectionOpts{
+			AffinityTimeout:      options.SelectionTimeout,
 			AcceptFirstAvailable: true,
 		}
 	}


### PR DESCRIPTION
allow setting the timeout for preflight requests on methods that don't use affinity based routing.