### PR TITLE
Allow specifying custom retry behavior in retry middleware

### DIFF
--- a/pkg/middleware/retry_test.go
+++ b/pkg/middleware/retry_test.go
@@ -1,0 +1,50 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/livekit/psrpc"
+	"google.golang.org/protobuf/proto"
+	"gotest.tools/v3/assert"
+)
+
+func TestRetryBackoff(t *testing.T) {
+	ro := RetryOptions{
+		MaxAttempts: 3,
+		Timeout:     100 * time.Millisecond,
+		Backoff:     200 * time.Millisecond,
+	}
+
+	t.Run("Failure, all errors retryable", func(t *testing.T) {
+		ro.IsRecoverable = func(err error) bool { return true }
+		ri := NewRPCRetryInterceptor(ro)
+
+		var timeouts []time.Duration
+
+		f := func(ctx context.Context, req proto.Message, opts ...psrpc.RequestOption) (res proto.Message, err error) {
+			o := &psrpc.RequestOpts{}
+
+			for _, f := range opts {
+				f(o)
+			}
+
+			timeouts = append(timeouts, o.Timeout)
+
+			return nil, errors.New("Test error")
+		}
+
+		h := ri(psrpc.RPCInfo{}, f)
+		h(context.Background(), nil)
+
+		assert.Equal(t, ro.MaxAttempts, len(timeouts))
+
+		expectedTimeout = ro.Timeout
+		for _, timeout := range timeouts {
+			assert.Equal(t, expectedTimeout, timeout)
+			expectedTimeout += ro.Backoff
+		}
+	})
+}

--- a/pkg/middleware/retry_test.go
+++ b/pkg/middleware/retry_test.go
@@ -39,7 +39,7 @@ func TestRetryBackoff(t *testing.T) {
 		}
 	}
 
-	t.Run("Success", func(t *testing.T) {
+	t.Run("TestSuccess", func(t *testing.T) {
 		ro.IsRecoverable = func(err error) bool { return true }
 		ri := NewRPCRetryInterceptor(ro)
 
@@ -51,7 +51,7 @@ func TestRetryBackoff(t *testing.T) {
 		require.Equal(t, ro.Timeout, timeouts[0])
 	})
 
-	t.Run("Failure all errors retryable", func(t *testing.T) {
+	t.Run("TestFailureAllErrorsRetryable", func(t *testing.T) {
 		ro.IsRecoverable = func(err error) bool { return true }
 		ri := NewRPCRetryInterceptor(ro)
 
@@ -69,5 +69,17 @@ func TestRetryBackoff(t *testing.T) {
 			require.Equal(t, expectedTimeout, timeout)
 			expectedTimeout += ro.Backoff
 		}
+	})
+
+	t.Run("TestFailureNoErrorRetryable", func(t *testing.T) {
+		ro.IsRecoverable = func(err error) bool { return false }
+		ri := NewRPCRetryInterceptor(ro)
+
+		errs := []error{errors.New("test error")}
+		h := ri(psrpc.RPCInfo{}, getClientRpcHandler(errs))
+		h(context.Background(), nil)
+
+		require.Equal(t, 1, len(timeouts))
+		require.Equal(t, ro.Timeout, timeouts[0])
 	})
 }

--- a/pkg/middleware/retry_test.go
+++ b/pkg/middleware/retry_test.go
@@ -84,10 +84,9 @@ func TestRetryBackoff(t *testing.T) {
 	})
 
 	t.Run("TestCustomParameters", func(t *testing.T) {
-		attempt := 1
 		lastTry := time.Now()
 
-		ro.GetRetryParameters = func(err error) (retry bool, timeout time.Duration, waitTime time.Duration) {
+		ro.GetRetryParameters = func(err error, attempt int) (retry bool, timeout time.Duration, waitTime time.Duration) {
 			if attempt > 1 {
 				now := time.Now()
 				require.InDelta(t, 500*time.Millisecond, now.Sub(lastTry), float64(20*time.Millisecond), "Retry didn't wait for required interval")
@@ -98,7 +97,6 @@ func TestRetryBackoff(t *testing.T) {
 				return false, 0, 0
 			}
 
-			attempt++
 			return true, 100 * time.Millisecond, 500 * time.Millisecond
 		}
 

--- a/pkg/middleware/retry_test.go
+++ b/pkg/middleware/retry_test.go
@@ -39,6 +39,18 @@ func TestRetryBackoff(t *testing.T) {
 		}
 	}
 
+	t.Run("Success", func(t *testing.T) {
+		ro.IsRecoverable = func(err error) bool { return true }
+		ri := NewRPCRetryInterceptor(ro)
+
+		errs := []error{nil}
+		h := ri(psrpc.RPCInfo{}, getClientRpcHandler(errs))
+		h(context.Background(), nil)
+
+		require.Equal(t, 1, len(timeouts))
+		require.Equal(t, ro.Timeout, timeouts[0])
+	})
+
 	t.Run("Failure, all errors retryable", func(t *testing.T) {
 		ro.IsRecoverable = func(err error) bool { return true }
 		ri := NewRPCRetryInterceptor(ro)

--- a/pkg/middleware/retry_test.go
+++ b/pkg/middleware/retry_test.go
@@ -51,7 +51,7 @@ func TestRetryBackoff(t *testing.T) {
 		require.Equal(t, ro.Timeout, timeouts[0])
 	})
 
-	t.Run("Failure, all errors retryable", func(t *testing.T) {
+	t.Run("Failure all errors retryable", func(t *testing.T) {
 		ro.IsRecoverable = func(err error) bool { return true }
 		ri := NewRPCRetryInterceptor(ro)
 


### PR DESCRIPTION
Add an optional `GetRetryParameters` function member to RetryOptions. When defined, this will be called before each retry attempt and allow specifying whether to retry, the timeout, and a duration to wait before retrying.

Also add a simple unit test for the retry middleware.