### PR TITLE
fix redis pubsub receive message

### DIFF
--- a/internal/bus/bus_redis.go
+++ b/internal/bus/bus_redis.go
@@ -156,7 +156,15 @@ func (r *redisMessageBus) readWorker() {
 	for {
 		msg, err := r.ps.ReceiveMessage(r.ctx)
 		if err != nil {
-			return
+			logger.Error(err, "redis receive message failed")
+
+			err = r.ps.Ping(r.ctx, "receive message failed")
+			if err != nil {
+				logger.Error(err, "redis ping failed")
+				time.Sleep(time.Millisecond * 100)
+			}
+
+			continue
 		}
 
 		r.mu.Lock()


### PR DESCRIPTION
Sometimes r.ps.ReceiveMessage(r.ctx) receives io.EOF (redis server closes connection), so we have to make reconnects in order to prevent getting stuck (MessageBus actually not works but everything looks fine, cause readWorker goroutine finished)