### PR TITLE
Update usage of core.Fuse

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/livekit/psrpc
 go 1.20
 
 require (
-	github.com/frostbyte73/core v0.0.9
+	github.com/frostbyte73/core v0.0.10
 	github.com/gammazero/deque v0.2.1
 	github.com/go-logr/logr v1.3.0
 	github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
-github.com/frostbyte73/core v0.0.9 h1:AmE9GjgGpPsWk9ZkmY3HsYUs2hf2tZt+/W6r49URBQI=
-github.com/frostbyte73/core v0.0.9/go.mod h1:XsOGqrqe/VEV7+8vJ+3a8qnCIXNbKsoEiu/czs7nrcU=
+github.com/frostbyte73/core v0.0.10 h1:D4DQXdPb8ICayz0n75rs4UYTXrUSdxzUfeleuNJORsU=
+github.com/frostbyte73/core v0.0.10/go.mod h1:XsOGqrqe/VEV7+8vJ+3a8qnCIXNbKsoEiu/czs7nrcU=
 github.com/gammazero/deque v0.2.1 h1:qSdsbG6pgp6nL7A0+K/B7s12mcCY/5l5SIUpMOl+dC0=
 github.com/gammazero/deque v0.2.1/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
 github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -59,7 +59,6 @@ func NewRPCClient(
 		claimRequests:     make(map[string]chan *internal.ClaimRequest),
 		responseChannels:  make(map[string]chan *internal.Response),
 		streamChannels:    make(map[string]chan *internal.Stream),
-		closed:            core.NewFuse(),
 	}
 	if c.ClientID != "" {
 		c.ID = c.ClientID

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -50,7 +50,6 @@ func NewRPCServer(sd *info.ServiceDefinition, b bus.MessageBus, opts ...psrpc.Se
 		ServerOpts:        getServerOpts(opts...),
 		bus:               b,
 		handlers:          make(map[string]rpcHandler),
-		shutdown:          core.NewFuse(),
 	}
 	if s.ServerID != "" {
 		s.ID = s.ServerID


### PR DESCRIPTION
Constructor for `core.Fuse` was removed in favor of using zero value directly (similar to `sync.Mutex` and friends). 