### PR TITLE
allow multirpc services to ignore requests

### DIFF
--- a/pkg/server/rpc.go
+++ b/pkg/server/rpc.go
@@ -186,6 +186,9 @@ func (h *rpcHandlerImpl[RequestType, ResponseType]) handleRequest(
 
 	// call handler function and return response
 	response, err := h.handler(ctx, req)
+	if ir.Multi && !response.ProtoReflect().IsValid() && err == nil {
+		return nil
+	}
 	return h.sendResponse(s, ctx, ir, response, err)
 }
 


### PR DESCRIPTION
for methods like `CheckEnabled` in the agent service returning false is handled the same as if there were no response.