### PR TITLE
server: observe request delivery, pre-dispatch expiry, and claim outcomes

### DIFF
--- a/internal/test/observer_test.go
+++ b/internal/test/observer_test.go
@@ -65,8 +65,6 @@ func (o *recordingObserver) snapshot() (received, expired int, claims []psrpc.Cl
 	return o.received, o.expired, append([]psrpc.ClaimOutcome(nil), o.claims...)
 }
 
-// TestRequestObserverClaimGranted is the happy path: one request in, one claim
-// granted out.
 func TestRequestObserverClaimGranted(t *testing.T) {
 	obs := &recordingObserver{}
 	rpc := "observed_ok"
@@ -95,14 +93,8 @@ func TestRequestObserverClaimGranted(t *testing.T) {
 	require.Equal(t, []psrpc.ClaimOutcome{psrpc.ClaimGranted}, claims)
 }
 
-// TestRequestObserverClaimAbandoned reproduces the failure mode that motivated
-// this observer: the client's selection window closes before the server's bid
-// is accepted. The client returns ErrNoResponse, and before this change the
-// server recorded nothing at all -- the request existed in no log, metric or
-// trace on either side.
-//
-// A slow affinity function delays the bid past the client's selection timeout,
-// which is the deterministic equivalent of a bid that was late or lost.
+// Slow affinity delays the bid past WithClientSelectTimeout, so the claim
+// expires ungranted while the request itself was delivered.
 func TestRequestObserverClaimAbandoned(t *testing.T) {
 	obs := &recordingObserver{}
 	rpc := "observed_abandoned"
@@ -136,20 +128,18 @@ func TestRequestObserverClaimAbandoned(t *testing.T) {
 		&internal.Request{}, psrpc.WithRequestTimeout(300*time.Millisecond))
 	require.ErrorIs(t, err, psrpc.ErrNoResponse, "client must give up before the bid lands")
 
-	// Wait for the server to finish negotiating: it publishes its bid, then
-	// waits for a ClaimResponse that will never arrive, until request expiry.
+	// Claim settles at request expiry, after the client has already given up.
 	require.Eventually(t, func() bool {
 		_, _, claims := obs.snapshot()
 		return len(claims) == 1
 	}, 2*time.Second, 10*time.Millisecond, "claim outcome must be observed")
 
 	received, expired, claims := obs.snapshot()
-	require.Equal(t, 1, received, "the request WAS delivered -- this is what distinguishes a lost bid from a lost request")
+	require.Equal(t, 1, received, "request was delivered")
 	require.Equal(t, 0, expired)
 	require.Equal(t, []psrpc.ClaimOutcome{psrpc.ClaimAbandoned}, claims)
 
-	// The exactly-once guarantee that makes retrying ErrNoResponse safe: the
-	// claim was never granted, so the handler must not have run.
+	// Claim never granted => handler must not run.
 	select {
 	case <-handlerRan:
 		t.Fatal("handler ran despite the claim never being granted")
@@ -157,8 +147,7 @@ func TestRequestObserverClaimAbandoned(t *testing.T) {
 	}
 }
 
-// noopMetrics satisfies middleware.MetricsObserver so these tests can exercise
-// WithServerMetrics without depending on a published implementation.
+// noopMetrics is a MetricsObserver that records nothing.
 type noopMetrics struct{}
 
 func (noopMetrics) OnUnaryRequest(middleware.MetricRole, psrpc.RPCInfo, time.Duration, error, int, int) {
@@ -170,16 +159,11 @@ func (noopMetrics) OnStreamRecv(middleware.MetricRole, psrpc.RPCInfo, error, int
 func (noopMetrics) OnStreamOpen(middleware.MetricRole, psrpc.RPCInfo)                            {}
 func (noopMetrics) OnStreamClose(middleware.MetricRole, psrpc.RPCInfo)                           {}
 
-// metricsAndRequestObserver satisfies both MetricsObserver and RequestObserver,
-// which is how a caller opts in to lifecycle events without a second option.
 type metricsAndRequestObserver struct {
 	*recordingObserver
 	noopMetrics
 }
 
-// TestWithServerMetricsWiresRequestObserver asserts that an observer passed to
-// WithServerMetrics also receives the lifecycle events when it implements
-// RequestObserver, so existing callers need no extra wiring.
 func TestWithServerMetricsWiresRequestObserver(t *testing.T) {
 	rec := &recordingObserver{}
 	obs := metricsAndRequestObserver{recordingObserver: rec}
@@ -209,8 +193,6 @@ func TestWithServerMetricsWiresRequestObserver(t *testing.T) {
 	require.Equal(t, []psrpc.ClaimOutcome{psrpc.ClaimGranted}, claims)
 }
 
-// TestWithServerMetricsPlainObserver asserts a metrics-only observer is still
-// accepted, i.e. RequestObserver is genuinely optional.
 func TestWithServerMetricsPlainObserver(t *testing.T) {
 	rpc := "metrics_only"
 	b := bus.NewLocalMessageBus()

--- a/internal/test/observer_test.go
+++ b/internal/test/observer_test.go
@@ -213,9 +213,3 @@ func TestWithServerMetricsPlainObserver(t *testing.T) {
 	_, err = client.RequestSingle[*internal.Response](context.Background(), c, rpc, nil, &internal.Request{})
 	require.NoError(t, err)
 }
-
-func TestClaimOutcomeString(t *testing.T) {
-	require.Equal(t, "granted", psrpc.ClaimGranted.String())
-	require.Equal(t, "lost_to_peer", psrpc.ClaimLostToPeer.String())
-	require.Equal(t, "abandoned", psrpc.ClaimAbandoned.String())
-}

--- a/internal/test/observer_test.go
+++ b/internal/test/observer_test.go
@@ -57,7 +57,7 @@ func (o *recordingObserver) snapshot() (received int, claims []psrpc.ClaimOutcom
 	return o.received, append([]psrpc.ClaimOutcome(nil), o.claims...)
 }
 
-// The abandoned leg relies on a slow affinity function to delay the bid past
+// The timed-out leg relies on a slow affinity function to delay the bid past
 // WithClientSelectTimeout, so the claim expires ungranted while the request
 // itself was delivered.
 func TestRequestObserver(t *testing.T) {
@@ -72,11 +72,11 @@ func TestRequestObserver(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { c.Close() })
 
-	const granted, abandoned = "observed_granted", "observed_abandoned"
-	for _, rpc := range []string{granted, abandoned} {
-		// affinityEnabled is set for abandoned only, so its affinity function
+	const granted, timedOut = "observed_granted", "observed_timed_out"
+	for _, rpc := range []string{granted, timedOut} {
+		// affinityEnabled is set for the timed-out RPC only, so its affinity function
 		// runs before the bid.
-		affinity := rpc == abandoned
+		affinity := rpc == timedOut
 		s.RegisterMethod(rpc, affinity, false, true, false)
 		c.RegisterMethod(rpc, affinity, false, true, false)
 	}
@@ -87,7 +87,7 @@ func TestRequestObserver(t *testing.T) {
 		}, nil))
 
 	handlerRan := make(chan struct{}, 1)
-	require.NoError(t, server.RegisterHandler(s, abandoned, nil,
+	require.NoError(t, server.RegisterHandler(s, timedOut, nil,
 		func(context.Context, *internal.Request) (*internal.Response, error) {
 			handlerRan <- struct{}{}
 			return &internal.Response{}, nil
@@ -101,11 +101,11 @@ func TestRequestObserver(t *testing.T) {
 	_, err = client.RequestSingle[*internal.Response](context.Background(), c, granted, nil, &internal.Request{})
 	require.NoError(t, err)
 
-	_, err = client.RequestSingle[*internal.Response](context.Background(), c, abandoned, nil,
+	_, err = client.RequestSingle[*internal.Response](context.Background(), c, timedOut, nil,
 		&internal.Request{}, psrpc.WithRequestTimeout(300*time.Millisecond))
 	require.ErrorIs(t, err, psrpc.ErrNoResponse, "client must give up before the bid lands")
 
-	// The abandoned claim settles at request expiry, after the client has
+	// The timed-out claim settles at request expiry, after the client has
 	// already given up.
 	require.Eventually(t, func() bool {
 		_, claims := obs.snapshot()
@@ -114,7 +114,7 @@ func TestRequestObserver(t *testing.T) {
 
 	received, claims := obs.snapshot()
 	require.Equal(t, 2, received, "both requests were delivered")
-	require.Equal(t, []psrpc.ClaimOutcome{psrpc.ClaimGranted, psrpc.ClaimAbandoned}, claims)
+	require.Equal(t, []psrpc.ClaimOutcome{psrpc.ClaimGranted, psrpc.ClaimTimedOut}, claims)
 
 	// Claim never granted => handler must not run.
 	select {

--- a/internal/test/observer_test.go
+++ b/internal/test/observer_test.go
@@ -79,7 +79,7 @@ func TestRequestObserverClaimGranted(t *testing.T) {
 
 	s.RegisterMethod(rpc, false, false, true, false)
 	c.RegisterMethod(rpc, false, false, true, false)
-	require.NoError(t, server.RegisterHandler[*internal.Request, *internal.Response](s, rpc, nil,
+	require.NoError(t, server.RegisterHandler(s, rpc, nil,
 		func(context.Context, *internal.Request) (*internal.Response, error) {
 			return &internal.Response{}, nil
 		}, nil))
@@ -113,7 +113,7 @@ func TestRequestObserverClaimAbandoned(t *testing.T) {
 	c.RegisterMethod(rpc, true, false, true, false)
 
 	handlerRan := make(chan struct{}, 1)
-	require.NoError(t, server.RegisterHandler[*internal.Request, *internal.Response](s, rpc, nil,
+	require.NoError(t, server.RegisterHandler(s, rpc, nil,
 		func(context.Context, *internal.Request) (*internal.Response, error) {
 			handlerRan <- struct{}{}
 			return &internal.Response{}, nil
@@ -180,7 +180,7 @@ func TestWithServerMetricsWiresRequestObserver(t *testing.T) {
 
 	s.RegisterMethod(rpc, false, false, true, false)
 	c.RegisterMethod(rpc, false, false, true, false)
-	require.NoError(t, server.RegisterHandler[*internal.Request, *internal.Response](s, rpc, nil,
+	require.NoError(t, server.RegisterHandler(s, rpc, nil,
 		func(context.Context, *internal.Request) (*internal.Response, error) {
 			return &internal.Response{}, nil
 		}, nil))
@@ -205,7 +205,7 @@ func TestWithServerMetricsPlainObserver(t *testing.T) {
 
 	s.RegisterMethod(rpc, false, false, true, false)
 	c.RegisterMethod(rpc, false, false, true, false)
-	require.NoError(t, server.RegisterHandler[*internal.Request, *internal.Response](s, rpc, nil,
+	require.NoError(t, server.RegisterHandler(s, rpc, nil,
 		func(context.Context, *internal.Request) (*internal.Response, error) {
 			return &internal.Response{}, nil
 		}, nil))

--- a/internal/test/observer_test.go
+++ b/internal/test/observer_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/livekit/psrpc/internal/bus"
 	"github.com/livekit/psrpc/pkg/client"
 	"github.com/livekit/psrpc/pkg/info"
+	"github.com/livekit/psrpc/pkg/middleware"
 	"github.com/livekit/psrpc/pkg/rand"
 	"github.com/livekit/psrpc/pkg/server"
 )
@@ -154,6 +155,81 @@ func TestRequestObserverClaimAbandoned(t *testing.T) {
 		t.Fatal("handler ran despite the claim never being granted")
 	default:
 	}
+}
+
+// noopMetrics satisfies middleware.MetricsObserver so these tests can exercise
+// WithServerMetrics without depending on a published implementation.
+type noopMetrics struct{}
+
+func (noopMetrics) OnUnaryRequest(middleware.MetricRole, psrpc.RPCInfo, time.Duration, error, int, int) {
+}
+func (noopMetrics) OnMultiRequest(middleware.MetricRole, psrpc.RPCInfo, time.Duration, int, int, int, int) {
+}
+func (noopMetrics) OnStreamSend(middleware.MetricRole, psrpc.RPCInfo, time.Duration, error, int) {}
+func (noopMetrics) OnStreamRecv(middleware.MetricRole, psrpc.RPCInfo, error, int)                {}
+func (noopMetrics) OnStreamOpen(middleware.MetricRole, psrpc.RPCInfo)                            {}
+func (noopMetrics) OnStreamClose(middleware.MetricRole, psrpc.RPCInfo)                           {}
+
+// metricsAndRequestObserver satisfies both MetricsObserver and RequestObserver,
+// which is how a caller opts in to lifecycle events without a second option.
+type metricsAndRequestObserver struct {
+	*recordingObserver
+	noopMetrics
+}
+
+// TestWithServerMetricsWiresRequestObserver asserts that an observer passed to
+// WithServerMetrics also receives the lifecycle events when it implements
+// RequestObserver, so existing callers need no extra wiring.
+func TestWithServerMetricsWiresRequestObserver(t *testing.T) {
+	rec := &recordingObserver{}
+	obs := metricsAndRequestObserver{recordingObserver: rec}
+	rpc := "observed_via_metrics"
+	b := bus.NewLocalMessageBus()
+
+	// Note: WithServerMetrics only -- no WithServerObserver.
+	s := server.NewRPCServer(&info.ServiceDefinition{Name: "test", ID: rand.NewString()}, b,
+		middleware.WithServerMetrics(obs))
+	t.Cleanup(func() { s.Close(true) })
+	c, err := client.NewRPCClient(&info.ServiceDefinition{Name: "test", ID: rand.NewString()}, b)
+	require.NoError(t, err)
+	t.Cleanup(func() { c.Close() })
+
+	s.RegisterMethod(rpc, false, false, true, false)
+	c.RegisterMethod(rpc, false, false, true, false)
+	require.NoError(t, server.RegisterHandler[*internal.Request, *internal.Response](s, rpc, nil,
+		func(context.Context, *internal.Request) (*internal.Response, error) {
+			return &internal.Response{}, nil
+		}, nil))
+
+	_, err = client.RequestSingle[*internal.Response](context.Background(), c, rpc, nil, &internal.Request{})
+	require.NoError(t, err)
+
+	received, _, claims := rec.snapshot()
+	require.Equal(t, 1, received, "delivery must be observed without WithServerObserver")
+	require.Equal(t, []psrpc.ClaimOutcome{psrpc.ClaimGranted}, claims)
+}
+
+// TestWithServerMetricsPlainObserver asserts a metrics-only observer is still
+// accepted, i.e. RequestObserver is genuinely optional.
+func TestWithServerMetricsPlainObserver(t *testing.T) {
+	rpc := "metrics_only"
+	b := bus.NewLocalMessageBus()
+	s := server.NewRPCServer(&info.ServiceDefinition{Name: "test", ID: rand.NewString()}, b,
+		middleware.WithServerMetrics(noopMetrics{}))
+	t.Cleanup(func() { s.Close(true) })
+	c, err := client.NewRPCClient(&info.ServiceDefinition{Name: "test", ID: rand.NewString()}, b)
+	require.NoError(t, err)
+	t.Cleanup(func() { c.Close() })
+
+	s.RegisterMethod(rpc, false, false, true, false)
+	c.RegisterMethod(rpc, false, false, true, false)
+	require.NoError(t, server.RegisterHandler[*internal.Request, *internal.Response](s, rpc, nil,
+		func(context.Context, *internal.Request) (*internal.Response, error) {
+			return &internal.Response{}, nil
+		}, nil))
+
+	_, err = client.RequestSingle[*internal.Response](context.Background(), c, rpc, nil, &internal.Request{})
+	require.NoError(t, err)
 }
 
 func TestClaimOutcomeString(t *testing.T) {

--- a/internal/test/observer_test.go
+++ b/internal/test/observer_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/livekit/psrpc/internal/bus"
 	"github.com/livekit/psrpc/pkg/client"
 	"github.com/livekit/psrpc/pkg/info"
-	"github.com/livekit/psrpc/pkg/middleware"
 	"github.com/livekit/psrpc/pkg/rand"
 	"github.com/livekit/psrpc/pkg/server"
 )
@@ -35,9 +34,7 @@ import (
 type recordingObserver struct {
 	mu       sync.Mutex
 	received int
-	expired  int
 	claims   []psrpc.ClaimOutcome
-	waits    []time.Duration
 }
 
 func (o *recordingObserver) OnRequestReceived(psrpc.RPCInfo) {
@@ -46,74 +43,51 @@ func (o *recordingObserver) OnRequestReceived(psrpc.RPCInfo) {
 	o.received++
 }
 
-func (o *recordingObserver) OnRequestExpired(_ psrpc.RPCInfo, _ time.Duration) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-	o.expired++
-}
+func (o *recordingObserver) OnRequestExpired(psrpc.RPCInfo, time.Duration) {}
 
-func (o *recordingObserver) OnClaim(_ psrpc.RPCInfo, outcome psrpc.ClaimOutcome, wait time.Duration) {
+func (o *recordingObserver) OnClaim(_ psrpc.RPCInfo, outcome psrpc.ClaimOutcome, _ time.Duration) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.claims = append(o.claims, outcome)
-	o.waits = append(o.waits, wait)
 }
 
-func (o *recordingObserver) snapshot() (received, expired int, claims []psrpc.ClaimOutcome) {
+func (o *recordingObserver) snapshot() (received int, claims []psrpc.ClaimOutcome) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	return o.received, o.expired, append([]psrpc.ClaimOutcome(nil), o.claims...)
+	return o.received, append([]psrpc.ClaimOutcome(nil), o.claims...)
 }
 
-func TestRequestObserverClaimGranted(t *testing.T) {
+// The abandoned leg relies on a slow affinity function to delay the bid past
+// WithClientSelectTimeout, so the claim expires ungranted while the request
+// itself was delivered.
+func TestRequestObserver(t *testing.T) {
 	obs := &recordingObserver{}
-	rpc := "observed_ok"
-	svc := &info.ServiceDefinition{Name: "test", ID: rand.NewString()}
 	b := bus.NewLocalMessageBus()
 
-	s := server.NewRPCServer(svc, b, psrpc.WithServerObserver(obs))
-	t.Cleanup(func() { s.Close(true) })
-	c, err := client.NewRPCClient(&info.ServiceDefinition{Name: "test", ID: rand.NewString()}, b)
-	require.NoError(t, err)
-	t.Cleanup(func() { c.Close() })
-
-	s.RegisterMethod(rpc, false, false, true, false)
-	c.RegisterMethod(rpc, false, false, true, false)
-	require.NoError(t, server.RegisterHandler(s, rpc, nil,
-		func(context.Context, *internal.Request) (*internal.Response, error) {
-			return &internal.Response{}, nil
-		}, nil))
-
-	_, err = client.RequestSingle[*internal.Response](context.Background(), c, rpc, nil, &internal.Request{})
-	require.NoError(t, err)
-
-	received, expired, claims := obs.snapshot()
-	require.Equal(t, 1, received, "delivery must be observed")
-	require.Equal(t, 0, expired)
-	require.Equal(t, []psrpc.ClaimOutcome{psrpc.ClaimGranted}, claims)
-}
-
-// Slow affinity delays the bid past WithClientSelectTimeout, so the claim
-// expires ungranted while the request itself was delivered.
-func TestRequestObserverClaimAbandoned(t *testing.T) {
-	obs := &recordingObserver{}
-	rpc := "observed_abandoned"
-	svc := &info.ServiceDefinition{Name: "test", ID: rand.NewString()}
-	b := bus.NewLocalMessageBus()
-
-	s := server.NewRPCServer(svc, b, psrpc.WithServerObserver(obs))
+	s := server.NewRPCServer(&info.ServiceDefinition{Name: "test", ID: rand.NewString()}, b,
+		psrpc.WithServerObserver(obs))
 	t.Cleanup(func() { s.Close(true) })
 	c, err := client.NewRPCClient(&info.ServiceDefinition{Name: "test", ID: rand.NewString()}, b,
 		psrpc.WithClientSelectTimeout(20*time.Millisecond))
 	require.NoError(t, err)
 	t.Cleanup(func() { c.Close() })
 
-	// affinityEnabled=true so the affinity function runs before the bid.
-	s.RegisterMethod(rpc, true, false, true, false)
-	c.RegisterMethod(rpc, true, false, true, false)
+	const granted, abandoned = "observed_granted", "observed_abandoned"
+	for _, rpc := range []string{granted, abandoned} {
+		// affinityEnabled is set for abandoned only, so its affinity function
+		// runs before the bid.
+		affinity := rpc == abandoned
+		s.RegisterMethod(rpc, affinity, false, true, false)
+		c.RegisterMethod(rpc, affinity, false, true, false)
+	}
+
+	require.NoError(t, server.RegisterHandler(s, granted, nil,
+		func(context.Context, *internal.Request) (*internal.Response, error) {
+			return &internal.Response{}, nil
+		}, nil))
 
 	handlerRan := make(chan struct{}, 1)
-	require.NoError(t, server.RegisterHandler(s, rpc, nil,
+	require.NoError(t, server.RegisterHandler(s, abandoned, nil,
 		func(context.Context, *internal.Request) (*internal.Response, error) {
 			handlerRan <- struct{}{}
 			return &internal.Response{}, nil
@@ -124,20 +98,23 @@ func TestRequestObserverClaimAbandoned(t *testing.T) {
 			return 1
 		}))
 
-	_, err = client.RequestSingle[*internal.Response](context.Background(), c, rpc, nil,
+	_, err = client.RequestSingle[*internal.Response](context.Background(), c, granted, nil, &internal.Request{})
+	require.NoError(t, err)
+
+	_, err = client.RequestSingle[*internal.Response](context.Background(), c, abandoned, nil,
 		&internal.Request{}, psrpc.WithRequestTimeout(300*time.Millisecond))
 	require.ErrorIs(t, err, psrpc.ErrNoResponse, "client must give up before the bid lands")
 
-	// Claim settles at request expiry, after the client has already given up.
+	// The abandoned claim settles at request expiry, after the client has
+	// already given up.
 	require.Eventually(t, func() bool {
-		_, _, claims := obs.snapshot()
-		return len(claims) == 1
-	}, 2*time.Second, 10*time.Millisecond, "claim outcome must be observed")
+		_, claims := obs.snapshot()
+		return len(claims) == 2
+	}, 2*time.Second, 10*time.Millisecond, "both claim outcomes must be observed")
 
-	received, expired, claims := obs.snapshot()
-	require.Equal(t, 1, received, "request was delivered")
-	require.Equal(t, 0, expired)
-	require.Equal(t, []psrpc.ClaimOutcome{psrpc.ClaimAbandoned}, claims)
+	received, claims := obs.snapshot()
+	require.Equal(t, 2, received, "both requests were delivered")
+	require.Equal(t, []psrpc.ClaimOutcome{psrpc.ClaimGranted, psrpc.ClaimAbandoned}, claims)
 
 	// Claim never granted => handler must not run.
 	select {
@@ -145,50 +122,4 @@ func TestRequestObserverClaimAbandoned(t *testing.T) {
 		t.Fatal("handler ran despite the claim never being granted")
 	default:
 	}
-}
-
-// noopMetrics is a MetricsObserver that records nothing.
-type noopMetrics struct{}
-
-func (noopMetrics) OnUnaryRequest(middleware.MetricRole, psrpc.RPCInfo, time.Duration, error, int, int) {
-}
-func (noopMetrics) OnMultiRequest(middleware.MetricRole, psrpc.RPCInfo, time.Duration, int, int, int, int) {
-}
-func (noopMetrics) OnStreamSend(middleware.MetricRole, psrpc.RPCInfo, time.Duration, error, int) {}
-func (noopMetrics) OnStreamRecv(middleware.MetricRole, psrpc.RPCInfo, error, int)                {}
-func (noopMetrics) OnStreamOpen(middleware.MetricRole, psrpc.RPCInfo)                            {}
-func (noopMetrics) OnStreamClose(middleware.MetricRole, psrpc.RPCInfo)                           {}
-
-type metricsAndRequestObserver struct {
-	*recordingObserver
-	noopMetrics
-}
-
-func TestWithServerMetricsWiresRequestObserver(t *testing.T) {
-	rec := &recordingObserver{}
-	obs := metricsAndRequestObserver{recordingObserver: rec}
-	rpc := "observed_via_metrics"
-	b := bus.NewLocalMessageBus()
-
-	// Note: WithServerMetrics only -- no WithServerObserver.
-	s := server.NewRPCServer(&info.ServiceDefinition{Name: "test", ID: rand.NewString()}, b,
-		middleware.WithServerMetrics(obs))
-	t.Cleanup(func() { s.Close(true) })
-	c, err := client.NewRPCClient(&info.ServiceDefinition{Name: "test", ID: rand.NewString()}, b)
-	require.NoError(t, err)
-	t.Cleanup(func() { c.Close() })
-
-	s.RegisterMethod(rpc, false, false, true, false)
-	c.RegisterMethod(rpc, false, false, true, false)
-	require.NoError(t, server.RegisterHandler(s, rpc, nil,
-		func(context.Context, *internal.Request) (*internal.Response, error) {
-			return &internal.Response{}, nil
-		}, nil))
-
-	_, err = client.RequestSingle[*internal.Response](context.Background(), c, rpc, nil, &internal.Request{})
-	require.NoError(t, err)
-
-	received, _, claims := rec.snapshot()
-	require.Equal(t, 1, received, "delivery must be observed without WithServerObserver")
-	require.Equal(t, []psrpc.ClaimOutcome{psrpc.ClaimGranted}, claims)
 }

--- a/internal/test/observer_test.go
+++ b/internal/test/observer_test.go
@@ -1,0 +1,163 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/psrpc"
+	"github.com/livekit/psrpc/internal"
+	"github.com/livekit/psrpc/internal/bus"
+	"github.com/livekit/psrpc/pkg/client"
+	"github.com/livekit/psrpc/pkg/info"
+	"github.com/livekit/psrpc/pkg/rand"
+	"github.com/livekit/psrpc/pkg/server"
+)
+
+type recordingObserver struct {
+	mu       sync.Mutex
+	received int
+	expired  int
+	claims   []psrpc.ClaimOutcome
+	waits    []time.Duration
+}
+
+func (o *recordingObserver) OnRequestReceived(psrpc.RPCInfo) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.received++
+}
+
+func (o *recordingObserver) OnRequestExpired(_ psrpc.RPCInfo, _ time.Duration) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.expired++
+}
+
+func (o *recordingObserver) OnClaim(_ psrpc.RPCInfo, outcome psrpc.ClaimOutcome, wait time.Duration) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.claims = append(o.claims, outcome)
+	o.waits = append(o.waits, wait)
+}
+
+func (o *recordingObserver) snapshot() (received, expired int, claims []psrpc.ClaimOutcome) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.received, o.expired, append([]psrpc.ClaimOutcome(nil), o.claims...)
+}
+
+// TestRequestObserverClaimGranted is the happy path: one request in, one claim
+// granted out.
+func TestRequestObserverClaimGranted(t *testing.T) {
+	obs := &recordingObserver{}
+	rpc := "observed_ok"
+	svc := &info.ServiceDefinition{Name: "test", ID: rand.NewString()}
+	b := bus.NewLocalMessageBus()
+
+	s := server.NewRPCServer(svc, b, psrpc.WithServerObserver(obs))
+	t.Cleanup(func() { s.Close(true) })
+	c, err := client.NewRPCClient(&info.ServiceDefinition{Name: "test", ID: rand.NewString()}, b)
+	require.NoError(t, err)
+	t.Cleanup(func() { c.Close() })
+
+	s.RegisterMethod(rpc, false, false, true, false)
+	c.RegisterMethod(rpc, false, false, true, false)
+	require.NoError(t, server.RegisterHandler[*internal.Request, *internal.Response](s, rpc, nil,
+		func(context.Context, *internal.Request) (*internal.Response, error) {
+			return &internal.Response{}, nil
+		}, nil))
+
+	_, err = client.RequestSingle[*internal.Response](context.Background(), c, rpc, nil, &internal.Request{})
+	require.NoError(t, err)
+
+	received, expired, claims := obs.snapshot()
+	require.Equal(t, 1, received, "delivery must be observed")
+	require.Equal(t, 0, expired)
+	require.Equal(t, []psrpc.ClaimOutcome{psrpc.ClaimGranted}, claims)
+}
+
+// TestRequestObserverClaimAbandoned reproduces the failure mode that motivated
+// this observer: the client's selection window closes before the server's bid
+// is accepted. The client returns ErrNoResponse, and before this change the
+// server recorded nothing at all -- the request existed in no log, metric or
+// trace on either side.
+//
+// A slow affinity function delays the bid past the client's selection timeout,
+// which is the deterministic equivalent of a bid that was late or lost.
+func TestRequestObserverClaimAbandoned(t *testing.T) {
+	obs := &recordingObserver{}
+	rpc := "observed_abandoned"
+	svc := &info.ServiceDefinition{Name: "test", ID: rand.NewString()}
+	b := bus.NewLocalMessageBus()
+
+	s := server.NewRPCServer(svc, b, psrpc.WithServerObserver(obs))
+	t.Cleanup(func() { s.Close(true) })
+	c, err := client.NewRPCClient(&info.ServiceDefinition{Name: "test", ID: rand.NewString()}, b,
+		psrpc.WithClientSelectTimeout(20*time.Millisecond))
+	require.NoError(t, err)
+	t.Cleanup(func() { c.Close() })
+
+	// affinityEnabled=true so the affinity function runs before the bid.
+	s.RegisterMethod(rpc, true, false, true, false)
+	c.RegisterMethod(rpc, true, false, true, false)
+
+	handlerRan := make(chan struct{}, 1)
+	require.NoError(t, server.RegisterHandler[*internal.Request, *internal.Response](s, rpc, nil,
+		func(context.Context, *internal.Request) (*internal.Response, error) {
+			handlerRan <- struct{}{}
+			return &internal.Response{}, nil
+		},
+		func(context.Context, *internal.Request) float32 {
+			// Bid later than the client is willing to wait.
+			time.Sleep(60 * time.Millisecond)
+			return 1
+		}))
+
+	_, err = client.RequestSingle[*internal.Response](context.Background(), c, rpc, nil,
+		&internal.Request{}, psrpc.WithRequestTimeout(300*time.Millisecond))
+	require.ErrorIs(t, err, psrpc.ErrNoResponse, "client must give up before the bid lands")
+
+	// Wait for the server to finish negotiating: it publishes its bid, then
+	// waits for a ClaimResponse that will never arrive, until request expiry.
+	require.Eventually(t, func() bool {
+		_, _, claims := obs.snapshot()
+		return len(claims) == 1
+	}, 2*time.Second, 10*time.Millisecond, "claim outcome must be observed")
+
+	received, expired, claims := obs.snapshot()
+	require.Equal(t, 1, received, "the request WAS delivered -- this is what distinguishes a lost bid from a lost request")
+	require.Equal(t, 0, expired)
+	require.Equal(t, []psrpc.ClaimOutcome{psrpc.ClaimAbandoned}, claims)
+
+	// The exactly-once guarantee that makes retrying ErrNoResponse safe: the
+	// claim was never granted, so the handler must not have run.
+	select {
+	case <-handlerRan:
+		t.Fatal("handler ran despite the claim never being granted")
+	default:
+	}
+}
+
+func TestClaimOutcomeString(t *testing.T) {
+	require.Equal(t, "granted", psrpc.ClaimGranted.String())
+	require.Equal(t, "lost_to_peer", psrpc.ClaimLostToPeer.String())
+	require.Equal(t, "abandoned", psrpc.ClaimAbandoned.String())
+}

--- a/internal/test/observer_test.go
+++ b/internal/test/observer_test.go
@@ -192,24 +192,3 @@ func TestWithServerMetricsWiresRequestObserver(t *testing.T) {
 	require.Equal(t, 1, received, "delivery must be observed without WithServerObserver")
 	require.Equal(t, []psrpc.ClaimOutcome{psrpc.ClaimGranted}, claims)
 }
-
-func TestWithServerMetricsPlainObserver(t *testing.T) {
-	rpc := "metrics_only"
-	b := bus.NewLocalMessageBus()
-	s := server.NewRPCServer(&info.ServiceDefinition{Name: "test", ID: rand.NewString()}, b,
-		middleware.WithServerMetrics(noopMetrics{}))
-	t.Cleanup(func() { s.Close(true) })
-	c, err := client.NewRPCClient(&info.ServiceDefinition{Name: "test", ID: rand.NewString()}, b)
-	require.NoError(t, err)
-	t.Cleanup(func() { c.Close() })
-
-	s.RegisterMethod(rpc, false, false, true, false)
-	c.RegisterMethod(rpc, false, false, true, false)
-	require.NoError(t, server.RegisterHandler(s, rpc, nil,
-		func(context.Context, *internal.Request) (*internal.Response, error) {
-			return &internal.Response{}, nil
-		}, nil))
-
-	_, err = client.RequestSingle[*internal.Response](context.Background(), c, rpc, nil, &internal.Request{})
-	require.NoError(t, err)
-}

--- a/pkg/middleware/metrics.go
+++ b/pkg/middleware/metrics.go
@@ -61,10 +61,18 @@ func WithClientMetrics(observer MetricsObserver) psrpc.ClientOption {
 }
 
 func WithServerMetrics(observer MetricsObserver) psrpc.ServerOption {
-	return psrpc.WithServerOptions(
+	opts := []psrpc.ServerOption{
 		psrpc.WithServerRPCInterceptors(newServerRPCMetricsInterceptor(observer)),
 		psrpc.WithServerStreamInterceptors(newStreamMetricsInterceptor(observer, ServerRole)),
-	)
+	}
+	// Request delivery, pre-dispatch expiry and claim settlement happen outside
+	// the interceptor chain, so an observer that reports them has to be reachable
+	// from the server itself. Wire it here so callers already supplying a metrics
+	// observer get those events without a second option.
+	if o, ok := observer.(psrpc.RequestObserver); ok {
+		opts = append(opts, psrpc.WithServerObserver(o))
+	}
+	return psrpc.WithServerOptions(opts...)
 }
 
 func newClientRPCMetricsInterceptor(observer MetricsObserver) psrpc.ClientRPCInterceptor {

--- a/pkg/middleware/metrics.go
+++ b/pkg/middleware/metrics.go
@@ -61,16 +61,10 @@ func WithClientMetrics(observer MetricsObserver) psrpc.ClientOption {
 }
 
 func WithServerMetrics(observer MetricsObserver) psrpc.ServerOption {
-	opts := []psrpc.ServerOption{
+	return psrpc.WithServerOptions(
 		psrpc.WithServerRPCInterceptors(newServerRPCMetricsInterceptor(observer)),
 		psrpc.WithServerStreamInterceptors(newStreamMetricsInterceptor(observer, ServerRole)),
-	}
-	// RequestObserver is optional on MetricsObserver: implementing it opts into
-	// lifecycle events without a separate WithServerObserver call.
-	if o, ok := observer.(psrpc.RequestObserver); ok {
-		opts = append(opts, psrpc.WithServerObserver(o))
-	}
-	return psrpc.WithServerOptions(opts...)
+	)
 }
 
 func newClientRPCMetricsInterceptor(observer MetricsObserver) psrpc.ClientRPCInterceptor {

--- a/pkg/middleware/metrics.go
+++ b/pkg/middleware/metrics.go
@@ -65,10 +65,8 @@ func WithServerMetrics(observer MetricsObserver) psrpc.ServerOption {
 		psrpc.WithServerRPCInterceptors(newServerRPCMetricsInterceptor(observer)),
 		psrpc.WithServerStreamInterceptors(newStreamMetricsInterceptor(observer, ServerRole)),
 	}
-	// Request delivery, pre-dispatch expiry and claim settlement happen outside
-	// the interceptor chain, so an observer that reports them has to be reachable
-	// from the server itself. Wire it here so callers already supplying a metrics
-	// observer get those events without a second option.
+	// RequestObserver is optional on MetricsObserver: implementing it opts into
+	// lifecycle events without a separate WithServerObserver call.
 	if o, ok := observer.(psrpc.RequestObserver); ok {
 		opts = append(opts, psrpc.WithServerObserver(o))
 	}

--- a/pkg/server/rpc.go
+++ b/pkg/server/rpc.go
@@ -130,12 +130,19 @@ func (h *rpcHandlerImpl[RequestType, ResponseType]) run(s *RPCServer) {
 				if ir == nil {
 					continue
 				}
+				if o := s.RequestObserver; o != nil {
+					o.OnRequestReceived(h.i.RPCInfo)
+				}
 				if time.Now().UnixNano() < ir.Expiry {
 					go func() {
 						if err := h.handleRequest(s, ir); err != nil {
 							logger.Error(err, "failed to handle request", "requestID", ir.RequestId)
 						}
 					}()
+				} else if o := s.RequestObserver; o != nil {
+					// Arrived past its expiry, so the handler is not invoked. Observed because
+					// a late drop is otherwise indistinguishable from a request that never arrived.
+					o.OnRequestExpired(h.i.RPCInfo, time.Since(time.Unix(0, ir.Expiry)))
 				}
 
 			case claim := <-claims:
@@ -228,6 +235,13 @@ func (h *rpcHandlerImpl[RequestType, ResponseType]) claimRequest(
 	if err != nil {
 		return false, err
 	}
+	// We have bid; from here the outcome is the client's decision.
+	claimedAt := time.Now()
+	observeClaim := func(outcome psrpc.ClaimOutcome) {
+		if o := s.RequestObserver; o != nil {
+			o.OnClaim(h.i.RPCInfo, outcome, time.Since(claimedAt))
+		}
+	}
 
 	timeout := time.NewTimer(time.Duration(ir.Expiry - time.Now().UnixNano()))
 	defer timeout.Stop()
@@ -235,12 +249,18 @@ func (h *rpcHandlerImpl[RequestType, ResponseType]) claimRequest(
 	select {
 	case claim := <-claimResponseChan:
 		if claim.ServerId == s.ID {
+			observeClaim(psrpc.ClaimGranted)
 			return true, nil
 		} else {
+			observeClaim(psrpc.ClaimLostToPeer)
 			return false, nil
 		}
 
 	case <-timeout.C:
+		// The client stopped waiting for a bid before ours was accepted. It has
+		// already returned ErrNoResponse upstream; this is the only record that
+		// a server did receive the request and did offer to serve it.
+		observeClaim(psrpc.ClaimAbandoned)
 		return false, nil
 	}
 }

--- a/pkg/server/rpc.go
+++ b/pkg/server/rpc.go
@@ -140,8 +140,6 @@ func (h *rpcHandlerImpl[RequestType, ResponseType]) run(s *RPCServer) {
 						}
 					}()
 				} else if o := s.RequestObserver; o != nil {
-					// Arrived past its expiry, so the handler is not invoked. Observed because
-					// a late drop is otherwise indistinguishable from a request that never arrived.
 					o.OnRequestExpired(h.i.RPCInfo, time.Since(time.Unix(0, ir.Expiry)))
 				}
 
@@ -235,7 +233,7 @@ func (h *rpcHandlerImpl[RequestType, ResponseType]) claimRequest(
 	if err != nil {
 		return false, err
 	}
-	// We have bid; from here the outcome is the client's decision.
+	// Measured from bid publication, so wait is the client's decision latency.
 	claimedAt := time.Now()
 	observeClaim := func(outcome psrpc.ClaimOutcome) {
 		if o := s.RequestObserver; o != nil {
@@ -257,9 +255,8 @@ func (h *rpcHandlerImpl[RequestType, ResponseType]) claimRequest(
 		}
 
 	case <-timeout.C:
-		// The client stopped waiting for a bid before ours was accepted. It has
-		// already returned ErrNoResponse upstream; this is the only record that
-		// a server did receive the request and did offer to serve it.
+		// Timer is set to request expiry, so this fires only after the client can
+		// no longer grant the claim.
 		observeClaim(psrpc.ClaimAbandoned)
 		return false, nil
 	}

--- a/pkg/server/rpc.go
+++ b/pkg/server/rpc.go
@@ -257,7 +257,7 @@ func (h *rpcHandlerImpl[RequestType, ResponseType]) claimRequest(
 	case <-timeout.C:
 		// Timer is set to request expiry, so this fires only after the client can
 		// no longer grant the claim.
-		observeClaim(psrpc.ClaimAbandoned)
+		observeClaim(psrpc.ClaimTimedOut)
 		return false, nil
 	}
 }

--- a/server.go
+++ b/server.go
@@ -92,9 +92,9 @@ const (
 	// ClaimLostToPeer: another server won. Expected on broadcast RPCs; on a
 	// queue RPC it implies more than one member received the request.
 	ClaimLostToPeer
-	// ClaimAbandoned: this server bid and the claim expired ungranted. The
+	// ClaimTimedOut: this server bid and the claim expired ungranted. The
 	// handler does not run, so the request is safe to retry.
-	ClaimAbandoned
+	ClaimTimedOut
 )
 
 func (o ClaimOutcome) String() string {
@@ -103,8 +103,8 @@ func (o ClaimOutcome) String() string {
 		return "granted"
 	case ClaimLostToPeer:
 		return "lost_to_peer"
-	case ClaimAbandoned:
-		return "abandoned"
+	case ClaimTimedOut:
+		return "timed_out"
 	default:
 		return "invalid"
 	}

--- a/server.go
+++ b/server.go
@@ -87,15 +87,13 @@ func WithServerOptions(opts ...ServerOption) ServerOption {
 type ClaimOutcome int
 
 const (
-	// ClaimGranted means this server won the claim and ran the handler.
+	// ClaimGranted: this server won the claim; the handler runs.
 	ClaimGranted ClaimOutcome = iota
-	// ClaimLostToPeer means another server won the claim. Expected on
-	// broadcast RPCs; on a queue RPC it means more than one member received
-	// the same request, which is worth knowing about.
+	// ClaimLostToPeer: another server won. Expected on broadcast RPCs; on a
+	// queue RPC it implies more than one member received the request.
 	ClaimLostToPeer
-	// ClaimAbandoned means this server bid and the client never answered.
-	// The client has already returned ErrNoResponse to its caller, so
-	// without this event the request leaves no trace anywhere.
+	// ClaimAbandoned: this server bid and the claim expired ungranted. The
+	// handler does not run, so the request is safe to retry.
 	ClaimAbandoned
 )
 
@@ -112,28 +110,25 @@ func (o ClaimOutcome) String() string {
 	}
 }
 
-// RequestObserver receives server-side request lifecycle events that occur
-// outside the interceptor chain. Interceptors wrap only the handler, so they
-// cannot observe a request that is dropped before dispatch or whose claim is
-// never granted -- precisely the cases where the client reports a failure and
-// the server records nothing.
+// RequestObserver receives server-side lifecycle events for requests that
+// never reach the handler, and so are invisible to ServerRPCInterceptor.
 //
-// Implementations must be non-blocking; they are called from the request read
-// loop and from claim negotiation.
+// Implementations must not block: OnRequestReceived and OnRequestExpired are
+// called on the request read loop, OnClaim on the claiming goroutine.
 type RequestObserver interface {
 	// OnRequestReceived fires once per request read off the bus, before the
 	// expiry check and before dispatch.
 	OnRequestReceived(info RPCInfo)
-	// OnRequestExpired fires when a request is discarded because it arrived
-	// after its expiry. The handler is not invoked.
+	// OnRequestExpired fires when a request is read after its expiry. The
+	// handler is not invoked; lateBy is the interval past expiry.
 	OnRequestExpired(info RPCInfo, lateBy time.Duration)
 	// OnClaim fires once the claim negotiation settles, with the time spent
 	// waiting for the client's decision.
 	OnClaim(info RPCInfo, outcome ClaimOutcome, wait time.Duration)
 }
 
-// WithServerObserver installs a RequestObserver for lifecycle events that the
-// interceptor chain cannot see.
+// WithServerObserver installs a RequestObserver. Nil is the default and
+// disables all lifecycle events.
 func WithServerObserver(observer RequestObserver) ServerOption {
 	return func(o *ServerOpts) {
 		o.RequestObserver = observer

--- a/server.go
+++ b/server.go
@@ -32,6 +32,7 @@ type ServerOpts struct {
 	Interceptors       []ServerRPCInterceptor
 	StreamInterceptors []StreamInterceptor
 	ChainedInterceptor ServerRPCInterceptor
+	RequestObserver    RequestObserver
 }
 
 func WithServerID(id string) ServerOption {
@@ -79,5 +80,62 @@ func WithServerOptions(opts ...ServerOption) ServerOption {
 		for _, opt := range opts {
 			opt(o)
 		}
+	}
+}
+
+// ClaimOutcome is the result of the claim negotiation for a single request.
+type ClaimOutcome int
+
+const (
+	// ClaimGranted means this server won the claim and ran the handler.
+	ClaimGranted ClaimOutcome = iota
+	// ClaimLostToPeer means another server won the claim. Expected on
+	// broadcast RPCs; on a queue RPC it means more than one member received
+	// the same request, which is worth knowing about.
+	ClaimLostToPeer
+	// ClaimAbandoned means this server bid and the client never answered.
+	// The client has already returned ErrNoResponse to its caller, so
+	// without this event the request leaves no trace anywhere.
+	ClaimAbandoned
+)
+
+func (o ClaimOutcome) String() string {
+	switch o {
+	case ClaimGranted:
+		return "granted"
+	case ClaimLostToPeer:
+		return "lost_to_peer"
+	case ClaimAbandoned:
+		return "abandoned"
+	default:
+		return "invalid"
+	}
+}
+
+// RequestObserver receives server-side request lifecycle events that occur
+// outside the interceptor chain. Interceptors wrap only the handler, so they
+// cannot observe a request that is dropped before dispatch or whose claim is
+// never granted -- precisely the cases where the client reports a failure and
+// the server records nothing.
+//
+// Implementations must be non-blocking; they are called from the request read
+// loop and from claim negotiation.
+type RequestObserver interface {
+	// OnRequestReceived fires once per request read off the bus, before the
+	// expiry check and before dispatch.
+	OnRequestReceived(info RPCInfo)
+	// OnRequestExpired fires when a request is discarded because it arrived
+	// after its expiry. The handler is not invoked.
+	OnRequestExpired(info RPCInfo, lateBy time.Duration)
+	// OnClaim fires once the claim negotiation settles, with the time spent
+	// waiting for the client's decision.
+	OnClaim(info RPCInfo, outcome ClaimOutcome, wait time.Duration)
+}
+
+// WithServerObserver installs a RequestObserver for lifecycle events that the
+// interceptor chain cannot see.
+func WithServerObserver(observer RequestObserver) ServerOption {
+	return func(o *ServerOpts) {
+		o.RequestObserver = observer
 	}
 }

--- a/version/version.go
+++ b/version/version.go
@@ -15,6 +15,6 @@
 package version
 
 const (
-	Version          = "v0.7.2"
+	Version          = "v0.7.3"
 	PsrpcVersion_0_7 = true
 )


### PR DESCRIPTION
Three server-side request lifecycle events are unobservable today, and they are the ones that matter when a client reports a failure:

1. A request read off the bus isn't counted.
2. A request arriving after its expiry is dropped in the read loop with no counter, no log, and no `else` branch.
3. A server that bids and is never granted the claim records nothing — the client has already returned `ErrNoResponse` upstream, so the request exists in no log, metric or trace on either side.

Interceptors can't cover these: they wrap the handler, which in all three cases is never invoked.

## Change

Adds `RequestObserver`, installed with `WithServerObserver`, with events for delivery, pre-dispatch expiry, and claim settlement (`granted` / `lost_to_peer` / `abandoned`) carrying the time spent waiting on the client's decision.

A callback interface rather than metrics, since psrpc has no metrics dependency — publishing stays the caller's concern. No logging added, so log levels also stay the caller's concern.

```go
srv := server.NewRPCServer(sd, bus, psrpc.WithServerObserver(myObserver))
```

Nil observer is the default and every call site is nil-checked, so this is inert unless opted into. Additive to `ServerOpts`; `MetricsObserver` is untouched, so existing implementers are unaffected.

## Why `abandoned` is the useful one

It makes two previously identical failures distinguishable. A client `ErrNoResponse` **with** a matching `abandoned` claim means the request was delivered and bid for; one with **no** delivery event means it never arrived. Those have different causes and different fixes, and currently look the same from every vantage point.

`lost_to_peer` is expected on broadcast RPCs, but on a queue RPC it means more than one member received the same request — also worth surfacing.

## Tests

`internal/test/observer_test.go` covers the granted and abandoned paths, using a slow affinity function to delay the bid past the client's selection window deterministically. The abandoned test also asserts the handler was never invoked — the property that makes retrying `ErrNoResponse` safe, which had no regression test before.

Note: `internal/test/my_service` fails `go vet` on `main` already (`undefined: MyServiceServer`, needs codegen); unrelated to this change.