### PR TITLE
TEL-836 PSRPC interceptor for masking uncoded and unknown server errors

### DIFF
--- a/pkg/middleware/errormask.go
+++ b/pkg/middleware/errormask.go
@@ -1,0 +1,83 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"context"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/livekit/psrpc"
+)
+
+// InternalErrorMessage is the only message a masked error carries.
+const InternalErrorMessage = "internal error"
+
+// Logger is the subset of a structured logger WithServerErrorMasking needs. It is
+// declared here rather than imported so that psrpc stays free of logging dependencies;
+// livekit/protocol's logger.Logger satisfies it as is.
+type Logger interface {
+	Warnw(msg string, err error, keysAndValues ...any)
+}
+
+// WithServerErrorMasking replaces any error a handler returns that was never given a
+// deliberate code with an opaque internal error, so that internal detail (database
+// driver text, file paths, hostnames) cannot reach the caller. The original error is
+// logged as a warning: masking is not meant to lose it, and a warning is the signal that
+// a handler has an unclassified error path someone should go and give a code to.
+//
+// Errors that already carry a code are returned untouched, on the assumption that a code
+// was chosen along with a message fit for the caller to read.
+//
+// Should always be the first interceptor, so that it is outermost and its return value is
+// the one that gets serialized.
+func WithServerErrorMasking(l Logger) psrpc.ServerRPCInterceptor {
+	return func(ctx context.Context, req proto.Message, info psrpc.RPCInfo, handler psrpc.ServerRPCHandler) (proto.Message, error) {
+		res, err := handler(ctx, req)
+		if !needsMasking(err) {
+			return res, err
+		}
+
+		l.Warnw("masked an unhandled error returned from rpc", err, "rpc", info.Service+"/"+info.Method)
+
+		// The response is passed through untouched: this interceptor's job is to replace
+		// the error and nothing else. psrpc ignores the response whenever the error is
+		// non-nil, and res can only be whatever the handler itself returned.
+		//
+		// The masked error deliberately does not wrap its cause. sendResponse resolves the
+		// error to serialize by walking the Unwrap chain for a psrpc.Error, so a wrapped
+		// cause carrying a code would be found and sent instead of this one.
+		return res, psrpc.NewErrorf(psrpc.Internal, InternalErrorMessage)
+	}
+}
+
+// needsMasking reports whether err was never given a deliberate code.
+//
+// GetErrorCode reads the code a psrpc.Error was created with, and only falls back to a
+// gRPC status for errors from elsewhere. Reading the code back out of GRPCStatus instead
+// would run it through ErrorCode.ToGRPC, which maps every code it has no case for to
+// codes.Unknown and would therefore mask deliberately coded errors.
+//
+// Unknown counts as "no code" because that is what an unclassified error becomes in
+// transit: a server serializes it as its raw text with code Unknown, and
+// NewErrorFromResponse rebuilds it that way on the client. Masking on Unknown is what
+// stops an unclassified error leaked by one server from being relayed onward by the next.
+func needsMasking(err error) bool {
+	if err == nil {
+		return false
+	}
+	code, ok := psrpc.GetErrorCode(err)
+	return !ok || code == psrpc.Unknown
+}

--- a/pkg/middleware/errormask.go
+++ b/pkg/middleware/errormask.go
@@ -22,27 +22,17 @@ import (
 	"github.com/livekit/psrpc"
 )
 
-// InternalErrorMessage is the only message a masked error carries.
 const InternalErrorMessage = "internal error"
 
-// Logger is the subset of a structured logger WithServerErrorMasking needs. It is
-// declared here rather than imported so that psrpc stays free of logging dependencies;
-// livekit/protocol's logger.Logger satisfies it as is.
 type Logger interface {
 	Warnw(msg string, err error, keysAndValues ...any)
 }
 
-// WithServerErrorMasking replaces any error a handler returns that was never given a
-// deliberate code with an opaque internal error, so that internal detail (database
-// driver text, file paths, hostnames) cannot reach the caller. The original error is
-// logged as a warning: masking is not meant to lose it, and a warning is the signal that
-// a handler has an unclassified error path someone should go and give a code to.
-//
-// Errors that already carry a code are returned untouched, on the assumption that a code
-// was chosen along with a message fit for the caller to read.
-//
-// Should always be the first interceptor, so that it is outermost and its return value is
-// the one that gets serialized.
+// WithServerErrorMasking replaces errors with no status code or an Unknown code
+// with an opaque internal error. grpc-go otherwise serializes an uncoded error as
+// codes.Unknown carrying the full error string, which may leak internal details to the caller.
+// Must be the first interceptor in the chain (outermost), such that the masking logic is
+// applied to the final error
 func WithServerErrorMasking(l Logger) psrpc.ServerRPCInterceptor {
 	return func(ctx context.Context, req proto.Message, info psrpc.RPCInfo, handler psrpc.ServerRPCHandler) (proto.Message, error) {
 		res, err := handler(ctx, req)
@@ -54,26 +44,15 @@ func WithServerErrorMasking(l Logger) psrpc.ServerRPCInterceptor {
 
 		// The response is passed through untouched: this interceptor's job is to replace
 		// the error and nothing else. psrpc ignores the response whenever the error is
-		// non-nil, and res can only be whatever the handler itself returned.
-		//
-		// The masked error deliberately does not wrap its cause. sendResponse resolves the
-		// error to serialize by walking the Unwrap chain for a psrpc.Error, so a wrapped
-		// cause carrying a code would be found and sent instead of this one.
+		// non-nil, and res can only be whatever the handler itself returned
 		return res, psrpc.NewErrorf(psrpc.Internal, InternalErrorMessage)
 	}
 }
 
-// needsMasking reports whether err was never given a deliberate code.
-//
-// GetErrorCode reads the code a psrpc.Error was created with, and only falls back to a
-// gRPC status for errors from elsewhere. Reading the code back out of GRPCStatus instead
-// would run it through ErrorCode.ToGRPC, which maps every code it has no case for to
-// codes.Unknown and would therefore mask deliberately coded errors.
-//
-// Unknown counts as "no code" because that is what an unclassified error becomes in
-// transit: a server serializes it as its raw text with code Unknown, and
-// NewErrorFromResponse rebuilds it that way on the client. Masking on Unknown is what
-// stops an unclassified error leaked by one server from being relayed onward by the next.
+// needsMasking returns true if the error does not have a status code in its chain,
+// or if it's unknown. Unknown counts as "no code" because that is what an unclassified
+// error becomes once it has crossed a psrpc or gRPC boundary, so masking on it also
+// covers errors this service is relaying from another one
 func needsMasking(err error) bool {
 	if err == nil {
 		return false

--- a/pkg/middleware/errormask_test.go
+++ b/pkg/middleware/errormask_test.go
@@ -1,0 +1,161 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/livekit/psrpc"
+)
+
+// driverErr stands in for the class of error this interceptor exists to contain: text
+// produced by a dependency, never written with a caller in mind.
+var driverErr = errors.New(`ERROR: column "from_host" does not exist (SQLSTATE 42703)`)
+
+// internalMarkers are strings that must never appear in a caller-visible message
+var internalMarkers = []string{"SQLSTATE", "42703", "from_host", "does not exist"}
+
+func requireNoInternalDetail(t *testing.T, msg string) {
+	t.Helper()
+	for _, m := range internalMarkers {
+		require.NotContains(t, msg, m, "caller-visible message leaks internal detail")
+	}
+}
+
+type testLogger struct {
+	warnings []error
+}
+
+func (l *testLogger) Warnw(_ string, err error, _ ...any) {
+	l.warnings = append(l.warnings, err)
+}
+
+func TestNeedsMasking(t *testing.T) {
+	var cases = []struct {
+		Name string
+		Err  error
+		Exp  bool
+	}{
+		{Name: "nil", Err: nil, Exp: false},
+		{Name: "plain", Err: errors.New("boom"), Exp: true},
+		{Name: "driver", Err: driverErr, Exp: true},
+		{Name: "context canceled", Err: context.Canceled, Exp: true},
+
+		{Name: "psrpc unknown", Err: psrpc.NewErrorf(psrpc.Unknown, "pq: relation does not exist"), Exp: true},
+		{Name: "psrpc internal", Err: psrpc.NewErrorf(psrpc.Internal, "failed to list phone numbers"), Exp: false},
+		{Name: "psrpc not found", Err: psrpc.NewErrorf(psrpc.NotFound, "trunk not found"), Exp: false},
+		{Name: "psrpc invalid argument", Err: psrpc.NewErrorf(psrpc.InvalidArgument, "missing projectID"), Exp: false},
+
+		// These two codes have no case in ErrorCode.ToGRPC, so they map to codes.Unknown.
+		// Reading the code back out of GRPCStatus would mask them.
+		{Name: "psrpc not acceptable", Err: psrpc.NewErrorf(psrpc.NotAcceptable, "unsupported codec"), Exp: false},
+		{Name: "psrpc unprocessable entity", Err: psrpc.NewErrorf(psrpc.UnprocessableEntity, "unroutable dispatch rule"), Exp: false},
+
+		{Name: "grpc unknown", Err: status.Error(codes.Unknown, "pq: relation does not exist"), Exp: true},
+		{Name: "grpc internal", Err: status.Error(codes.Internal, "failed to search vendor inventory"), Exp: false},
+		{Name: "grpc canceled", Err: status.Error(codes.Canceled, "canceled"), Exp: false},
+	}
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			require.Equal(t, c.Exp, needsMasking(c.Err))
+			if c.Err != nil {
+				require.Equal(t, c.Exp, needsMasking(fmt.Errorf("wrapped: %w", c.Err)),
+					"wrapping must not change the verdict")
+			}
+		})
+	}
+}
+
+// TestNeedsMaskingRelayed covers an unclassified error that has already crossed a psrpc
+// boundary. The server serialized it as raw text with code Unknown and the client rebuilt
+// it with NewErrorFromResponse, so it arrives coded. It must still be masked, otherwise a
+// server relaying a response from another server would pass the leak along.
+func TestNeedsMaskingRelayed(t *testing.T) {
+	require.True(t, needsMasking(psrpc.NewErrorFromResponse(string(psrpc.Unknown), driverErr.Error())))
+	require.True(t, needsMasking(psrpc.NewErrorFromResponse("", driverErr.Error())))
+}
+
+func TestWithServerErrorMasking(t *testing.T) {
+	callReturning := func(l Logger, handlerRes proto.Message, handlerErr error) (proto.Message, error) {
+		return WithServerErrorMasking(l)(
+			context.Background(),
+			nil,
+			psrpc.RPCInfo{Service: "IOInfo", Method: "GetEgress"},
+			func(context.Context, proto.Message) (proto.Message, error) { return handlerRes, handlerErr },
+		)
+	}
+
+	t.Run("an unclassified error is masked and reported", func(t *testing.T) {
+		l := &testLogger{}
+
+		_, err := callReturning(l, nil, fmt.Errorf("failed to get egress: %w", driverErr))
+		require.Error(t, err)
+		require.Equal(t, InternalErrorMessage, err.Error())
+		requireNoInternalDetail(t, err.Error())
+
+		code, ok := psrpc.GetErrorCode(err)
+		require.True(t, ok)
+		require.Equal(t, psrpc.Internal, code)
+
+		// The detail must survive somewhere, or masking would simply lose it
+		require.Len(t, l.warnings, 1)
+		require.ErrorIs(t, l.warnings[0], driverErr)
+	})
+
+	t.Run("the cause is not reachable through the masked error", func(t *testing.T) {
+		_, err := callReturning(&testLogger{}, nil, psrpc.NewError(psrpc.Unknown, driverErr))
+
+		require.NotErrorIs(t, err, driverErr, "unwrapping must not reach the cause")
+		requireNoInternalDetail(t, err.Error())
+	})
+
+	t.Run("a deliberate code and message survive", func(t *testing.T) {
+		l := &testLogger{}
+
+		_, err := callReturning(l, nil, psrpc.NewErrorf(psrpc.NotFound, "egress not found"))
+		require.Equal(t, "egress not found", err.Error())
+
+		code, ok := psrpc.GetErrorCode(err)
+		require.True(t, ok)
+		require.Equal(t, psrpc.NotFound, code)
+
+		require.Empty(t, l.warnings, "a coded error is not something to warn about")
+	})
+
+	// NotAcceptable has no ErrorCode.ToGRPC case, so a predicate reading the code out of
+	// GRPCStatus would see codes.Unknown here and mask a deliberately coded error.
+	t.Run("a code with no gRPC equivalent survives", func(t *testing.T) {
+		_, err := callReturning(&testLogger{}, nil, psrpc.NewErrorf(psrpc.NotAcceptable, "unsupported codec"))
+		require.Equal(t, "unsupported codec", err.Error())
+
+		code, ok := psrpc.GetErrorCode(err)
+		require.True(t, ok)
+		require.Equal(t, psrpc.NotAcceptable, code)
+	})
+
+	t.Run("success passes through", func(t *testing.T) {
+		handlerRes := &emptypb.Empty{}
+
+		res, err := callReturning(&testLogger{}, handlerRes, nil)
+		require.NoError(t, err)
+		require.Same(t, handlerRes, res)
+	})
+
+	// Only the error is replaced. psrpc ignores the response when the error is non-nil,
+	// and res can only ever be what the handler returned, so there is nothing to gain from
+	// dropping it.
+	t.Run("a response returned alongside an error passes through", func(t *testing.T) {
+		handlerRes := &emptypb.Empty{}
+
+		res, err := callReturning(&testLogger{}, handlerRes, driverErr)
+		require.Error(t, err)
+		require.Same(t, handlerRes, res, "the handler's response must be returned unchanged")
+	})
+}

--- a/pkg/middleware/errormask_test.go
+++ b/pkg/middleware/errormask_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package middleware
 
 import (
@@ -15,11 +29,10 @@ import (
 	"github.com/livekit/psrpc"
 )
 
-// driverErr stands in for the class of error this interceptor exists to contain: text
-// produced by a dependency, never written with a caller in mind.
+// driverErr is an example error that should not be returned to the caller
 var driverErr = errors.New(`ERROR: column "from_host" does not exist (SQLSTATE 42703)`)
 
-// internalMarkers are strings that must never appear in a caller-visible message
+// internalMarkers are strings that should never appear in a caller-visible message
 var internalMarkers = []string{"SQLSTATE", "42703", "from_host", "does not exist"}
 
 func requireNoInternalDetail(t *testing.T, msg string) {


### PR DESCRIPTION
## Summary
- Adding an interceptor for psrpc calls that changes the error to an internal message (and logs a warning) when the intercepted error does not have a status code or an Unknown code

## Test
- Unit tests