### PR TITLE
test: synchronize the concurrent RPC counter

### DIFF
--- a/internal/test/psrpc_test.go
+++ b/internal/test/psrpc_test.go
@@ -16,6 +16,7 @@ package test
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -72,12 +73,12 @@ func testRPC(t *testing.T, bus bustest.Connect) {
 
 	retErr := psrpc.NewErrorf(psrpc.Internal, "foo")
 
-	counter := 0
+	var counter atomic.Int32
 	errCount := 0
 	rpc := "add_one"
 	multiRpc := "add_one_multi"
 	addOne := func(ctx context.Context, req *internal.Request) (*internal.Response, error) {
-		counter++
+		counter.Add(1)
 		return &internal.Response{RequestId: req.RequestId}, nil
 	}
 	returnError := func(ctx context.Context, req *internal.Request) (*internal.Response, error) {
@@ -101,7 +102,7 @@ func testRPC(t *testing.T, bus bustest.Connect) {
 	)
 
 	require.NoError(t, err)
-	require.Equal(t, 1, counter)
+	require.Equal(t, int32(1), counter.Load())
 	require.Equal(t, res.RequestId, requestID)
 
 	serverA.RegisterMethod(multiRpc, false, true, false, false)
@@ -127,7 +128,7 @@ func testRPC(t *testing.T, bus bustest.Connect) {
 		select {
 		case res := <-resChan:
 			if res == nil {
-				require.Equal(t, 3, counter)
+				require.Equal(t, int32(3), counter.Load())
 				require.Equal(t, 1, errCount)
 				return
 			}


### PR DESCRIPTION
## Summary

  Fix a data race in the shared RPC transport test by replacing the concurrently updated integer counter with `atomic.Int32`.

  This change only affects test synchronization and does not modify production RPC behavior.

  ## Problem

  The test registers the same `addOne` handler closure on multiple RPC servers:

  ```go
  counter := 0

  addOne := func(...) (...) {
      counter++
      ...
  }
```

  A multi-RPC request is delivered to those servers concurrently. Each server dispatches its handler in a separate goroutine, so multiple handlers can execute counter++ at the same time.

  counter++ is a read-modify-write operation rather than a single atomic operation. Concurrent executions therefore create a data race and can also lose updates:

  Goroutine A reads 1
  Goroutine B reads 1
  Goroutine A writes 2
  Goroutine B writes 2

  The expected result is 3, but a lost update can leave the counter at 2. The race is also reported by go test -race.

  ## Changes

  - Replace the shared integer with atomic.Int32.
  - Use counter.Add(1) inside the concurrently executed RPC handler.
  - Use counter.Load() when asserting the final value.
  - Keep errCount as a regular integer because it is only accessed by the single goroutine consuming responses.

  ## Why atomic instead of a mutex?

  The counter only requires independent increment and load operations. atomic.Int32 expresses that synchronization requirement directly without introducing additional lock scope into the test.