### PR TITLE
bus: make typed subscription shutdown safe

### DIFF
--- a/internal/bus/subscription.go
+++ b/internal/bus/subscription.go
@@ -26,8 +26,8 @@ type Subscription[MessageType proto.Message] interface {
 }
 
 type subscription[MessageType proto.Message] struct {
-	Reader
-	c         <-chan MessageType
+	sub       Reader
+	c         chan MessageType
 	done      chan struct{}
 	complete  chan struct{}
 	closeOnce sync.Once
@@ -35,41 +35,41 @@ type subscription[MessageType proto.Message] struct {
 }
 
 func newSubscription[MessageType proto.Message](sub Reader, size int, maxSize int) Subscription[MessageType] {
-	msgChan := make(chan MessageType, size)
 	s := &subscription[MessageType]{
-		Reader:   sub,
-		c:        msgChan,
+		sub:      sub,
+		c:        make(chan MessageType, size),
 		done:     make(chan struct{}),
 		complete: make(chan struct{}),
 	}
-	go func() {
-		defer func() {
-			close(msgChan)
-			close(s.complete)
-		}()
-		for {
-			b, ok := sub.read()
-			if !ok {
-				return
-			}
-
-			p, err := deserialize(b, maxSize)
-			if err != nil {
-				continue
-			}
-			msg, ok := p.(MessageType)
-			if !ok {
-				continue
-			}
-			select {
-			case msgChan <- msg:
-			case <-s.done:
-				return
-			}
-		}
-	}()
-
+	go s.forward(maxSize)
 	return s
+}
+
+func (s *subscription[MessageType]) forward(maxSize int) {
+	defer close(s.complete)
+	defer close(s.c)
+
+	for {
+		b, ok := s.sub.read()
+		if !ok {
+			return
+		}
+
+		p, err := deserialize(b, maxSize)
+		if err != nil {
+			continue
+		}
+		msg, ok := p.(MessageType)
+		if !ok {
+			continue
+		}
+
+		select {
+		case s.c <- msg:
+		case <-s.done:
+			return
+		}
+	}
 }
 
 func (s *subscription[MessageType]) Channel() <-chan MessageType {
@@ -79,8 +79,8 @@ func (s *subscription[MessageType]) Channel() <-chan MessageType {
 func (s *subscription[MessageType]) Close() error {
 	s.closeOnce.Do(func() {
 		close(s.done)
-		s.closeErr = s.Reader.Close()
+		s.closeErr = s.sub.Close()
+		<-s.complete
 	})
-	<-s.complete
 	return s.closeErr
 }

--- a/internal/bus/subscription.go
+++ b/internal/bus/subscription.go
@@ -15,6 +15,8 @@
 package bus
 
 import (
+	"sync"
+
 	"google.golang.org/protobuf/proto"
 )
 
@@ -25,16 +27,29 @@ type Subscription[MessageType proto.Message] interface {
 
 type subscription[MessageType proto.Message] struct {
 	Reader
-	c <-chan MessageType
+	c         <-chan MessageType
+	done      chan struct{}
+	complete  chan struct{}
+	closeOnce sync.Once
+	closeErr  error
 }
 
 func newSubscription[MessageType proto.Message](sub Reader, size int, maxSize int) Subscription[MessageType] {
 	msgChan := make(chan MessageType, size)
+	s := &subscription[MessageType]{
+		Reader:   sub,
+		c:        msgChan,
+		done:     make(chan struct{}),
+		complete: make(chan struct{}),
+	}
 	go func() {
+		defer func() {
+			close(msgChan)
+			close(s.complete)
+		}()
 		for {
 			b, ok := sub.read()
 			if !ok {
-				close(msgChan)
 				return
 			}
 
@@ -42,16 +57,30 @@ func newSubscription[MessageType proto.Message](sub Reader, size int, maxSize in
 			if err != nil {
 				continue
 			}
-			msgChan <- p.(MessageType)
+			msg, ok := p.(MessageType)
+			if !ok {
+				continue
+			}
+			select {
+			case msgChan <- msg:
+			case <-s.done:
+				return
+			}
 		}
 	}()
 
-	return &subscription[MessageType]{
-		Reader: sub,
-		c:      msgChan,
-	}
+	return s
 }
 
 func (s *subscription[MessageType]) Channel() <-chan MessageType {
 	return s.c
+}
+
+func (s *subscription[MessageType]) Close() error {
+	s.closeOnce.Do(func() {
+		close(s.done)
+		s.closeErr = s.Reader.Close()
+	})
+	<-s.complete
+	return s.closeErr
 }

--- a/internal/bus/subscription_test.go
+++ b/internal/bus/subscription_test.go
@@ -16,6 +16,7 @@ package bus
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -29,6 +30,7 @@ import (
 type controlledReader struct {
 	messages   chan []byte
 	reads      chan struct{}
+	closeErr   error
 	closeCalls atomic.Int32
 }
 
@@ -51,7 +53,7 @@ func (r *controlledReader) Close() error {
 	if r.closeCalls.Add(1) == 1 {
 		close(r.messages)
 	}
-	return nil
+	return r.closeErr
 }
 
 func TestSubscriptionIgnoresUnexpectedMessageType(t *testing.T) {
@@ -86,8 +88,8 @@ func TestSubscriptionCloseIsIdempotent(t *testing.T) {
 	select {
 	case _, ok := <-sub.Channel():
 		require.False(t, ok)
-	case <-time.After(time.Second):
-		t.Fatal("subscription channel did not close")
+	default:
+		t.Fatal("subscription channel was not closed before Close returned")
 	}
 }
 
@@ -115,13 +117,14 @@ func TestSubscriptionCloseUnblocksBlockedDelivery(t *testing.T) {
 	select {
 	case _, ok = <-sub.Channel():
 		require.False(t, ok)
-	case <-time.After(time.Second):
-		t.Fatal("subscription channel did not close after blocked delivery was canceled")
+	default:
+		t.Fatal("subscription channel was not closed before Close returned")
 	}
 }
 
 func TestSubscriptionConcurrentCloseCallsReaderOnce(t *testing.T) {
 	r := newControlledReader(0)
+	r.closeErr = errors.New("close failed")
 	sub := newSubscription[*internal.Request](r, 1, 0)
 
 	const callers = 16
@@ -136,14 +139,14 @@ func TestSubscriptionConcurrentCloseCallsReaderOnce(t *testing.T) {
 	close(start)
 
 	for range callers {
-		require.NoError(t, <-errs)
+		require.ErrorIs(t, <-errs, r.closeErr)
 	}
 	require.Equal(t, int32(1), r.closeCalls.Load())
 
 	select {
 	case _, ok := <-sub.Channel():
 		require.False(t, ok)
-	case <-time.After(time.Second):
-		t.Fatal("subscription channel did not close")
+	default:
+		t.Fatal("subscription channel was not closed before Close returned")
 	}
 }

--- a/internal/bus/subscription_test.go
+++ b/internal/bus/subscription_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bus
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/livekit/psrpc/internal"
+)
+
+type controlledReader struct {
+	messages   chan []byte
+	reads      chan struct{}
+	closeCalls atomic.Int32
+}
+
+func newControlledReader(size int) *controlledReader {
+	return &controlledReader{
+		messages: make(chan []byte, size),
+		reads:    make(chan struct{}, size),
+	}
+}
+
+func (r *controlledReader) read() ([]byte, bool) {
+	b, ok := <-r.messages
+	if ok {
+		r.reads <- struct{}{}
+	}
+	return b, ok
+}
+
+func (r *controlledReader) Close() error {
+	if r.closeCalls.Add(1) == 1 {
+		close(r.messages)
+	}
+	return nil
+}
+
+func TestSubscriptionIgnoresUnexpectedMessageType(t *testing.T) {
+	b := NewLocalMessageBus()
+	channel := Channel{Legacy: "test"}
+	sub, err := Subscribe[*internal.Request](context.Background(), b, channel, 1)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, sub.Close()) })
+
+	require.NoError(t, b.Publish(context.Background(), channel, &internal.Response{}))
+	want := &internal.Request{RequestId: "expected"}
+	require.NoError(t, b.Publish(context.Background(), channel, want))
+
+	select {
+	case got := <-sub.Channel():
+		require.True(t, proto.Equal(want, got))
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the expected message")
+	}
+}
+
+func TestSubscriptionCloseIsIdempotent(t *testing.T) {
+	b := NewLocalMessageBus()
+	sub, err := Subscribe[*internal.Request](
+		context.Background(), b, Channel{Legacy: "test"}, 1,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, sub.Close())
+	require.NoError(t, sub.Close())
+
+	select {
+	case _, ok := <-sub.Channel():
+		require.False(t, ok)
+	case <-time.After(time.Second):
+		t.Fatal("subscription channel did not close")
+	}
+}
+
+func TestSubscriptionCloseUnblocksBlockedDelivery(t *testing.T) {
+	r := newControlledReader(2)
+	sub := newSubscription[*internal.Request](r, 1, 0)
+
+	first := &internal.Request{RequestId: "first"}
+	second := &internal.Request{RequestId: "second"}
+	firstBytes, err := serialize(first, "", nil)
+	require.NoError(t, err)
+	secondBytes, err := serialize(second, "", nil)
+	require.NoError(t, err)
+
+	r.messages <- firstBytes
+	r.messages <- secondBytes
+	<-r.reads
+	<-r.reads
+
+	require.NoError(t, sub.Close())
+
+	got, ok := <-sub.Channel()
+	require.True(t, ok)
+	require.True(t, proto.Equal(first, got))
+	select {
+	case _, ok = <-sub.Channel():
+		require.False(t, ok)
+	case <-time.After(time.Second):
+		t.Fatal("subscription channel did not close after blocked delivery was canceled")
+	}
+}
+
+func TestSubscriptionConcurrentCloseCallsReaderOnce(t *testing.T) {
+	r := newControlledReader(0)
+	sub := newSubscription[*internal.Request](r, 1, 0)
+
+	const callers = 16
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	for range callers {
+		go func() {
+			<-start
+			errs <- sub.Close()
+		}()
+	}
+	close(start)
+
+	for range callers {
+		require.NoError(t, <-errs)
+	}
+	require.Equal(t, int32(1), r.closeCalls.Load())
+
+	select {
+	case _, ok := <-sub.Channel():
+		require.False(t, ok)
+	case <-time.After(time.Second):
+		t.Fatal("subscription channel did not close")
+	}
+}

--- a/pkg/server/rpc.go
+++ b/pkg/server/rpc.go
@@ -336,5 +336,4 @@ func (h *rpcHandlerImpl[RequestType, ResponseType]) close(force bool) {
 		h.onCompleted()
 		close(h.complete)
 	})
-	<-h.complete
 }

--- a/pkg/server/stream.go
+++ b/pkg/server/stream.go
@@ -284,7 +284,6 @@ func (h *streamHandler[RecvType, SendType]) close(force bool) {
 		h.onCompleted()
 		close(h.complete)
 	})
-	<-h.complete
 }
 
 type serverStream[SendType, RecvType proto.Message] struct {

--- a/version/version.go
+++ b/version/version.go
@@ -15,6 +15,6 @@
 package version
 
 const (
-	Version          = "v0.7.6"
+	Version          = "v0.7.7"
 	PsrpcVersion_0_7 = true
 )


### PR DESCRIPTION
  ## Summary

  Make typed subscription shutdown deterministic and safe when delivery is blocked, `Close` is called concurrently, or the underlying bus delivers an unexpected protobuf type.

  ## Problem

  Typed subscriptions use a forwarding goroutine to deserialize messages from the underlying `Reader` and deliver them to a typed Go channel.

  The previous implementation had several lifecycle problems:

  - If the consumer stopped reading after the typed channel became full, the forwarding goroutine blocked indefinitely while sending the next message.
  - Closing the underlying reader did not unblock that blocked delivery, so subscription shutdown could deadlock.
  - `Close` was inherited directly from the underlying `Reader`, allowing repeated or concurrent calls to close the reader multiple times.
  - The forwarding goroutine used an unchecked type assertion, so an unexpected protobuf type could panic the goroutine.
  - Callers had no guarantee that the typed output channel was closed before `Close` returned.

  ## Changes

  - Add a `done` channel to notify the forwarding goroutine that shutdown has started.
  - Make message delivery select between the typed output channel and the shutdown signal, allowing blocked delivery to be canceled.
  - Add a separate `complete` channel so `Close` waits until the forwarding goroutine has exited and closed the typed output channel.
  - Protect shutdown with `sync.Once`, ensuring the underlying reader is closed exactly once.
  - Preserve and return the underlying reader's close error to every caller.
  - Replace the unchecked protobuf type assertion with a checked assertion and ignore mismatched messages.

  The shutdown sequence is now:

  1. Signal the forwarding goroutine to stop.
  2. Close the underlying reader to unblock any pending read.
  3. Wait for the forwarding goroutine to exit.
  4. Return only after the typed output channel has been closed.

  ## Tests

  Add regression coverage for:

  - Ignoring an unexpected protobuf type without panicking.
  - Repeated `Close` calls.
  - Concurrent `Close` calls closing the underlying reader exactly once.
  - Closing while delivery is blocked by a full typed channel.
  - Ensuring the typed output channel is closed before `Close` returns.

  ## Verification

  - `go test ./internal/bus`
  - `go test -race ./internal/bus`
  - `go test ./...`