### PR TITLE
Terminate pending RPCs when RPCClient closes

### DIFF
--- a/pkg/client/lifecycle_test.go
+++ b/pkg/client/lifecycle_test.go
@@ -1,0 +1,247 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/livekit/psrpc"
+	"github.com/livekit/psrpc/internal"
+	"github.com/livekit/psrpc/internal/bus"
+	"github.com/livekit/psrpc/pkg/info"
+)
+
+func TestOpenStreamRejectsClosedClient(t *testing.T) {
+	sd := &info.ServiceDefinition{Name: "test", ID: "client"}
+	sd.RegisterMethod("stream", false, false, false, false)
+	c, err := NewRPCClientWithStreams(sd, bus.NewLocalMessageBus())
+	require.NoError(t, err)
+	c.Close()
+
+	_, err = OpenStream[*internal.Request, *internal.Response](
+		context.Background(), c, "stream", nil,
+	)
+	require.ErrorIs(t, err, psrpc.ErrClientClosed)
+}
+
+func TestOpenStreamStopsWhileWaitingForAckWhenClientCloses(t *testing.T) {
+	openPublished := make(chan struct{})
+	b := bus.NewTestBus(bus.NewLocalMessageBus(), func(o *bus.TestBusOpts) {
+		o.PublishInterceptors = append(o.PublishInterceptors, func(next bus.PublishHandler) bus.PublishHandler {
+			return func(ctx context.Context, channel bus.Channel, msg proto.Message) error {
+				err := next(ctx, channel, msg)
+				if streamMsg, ok := msg.(*internal.Stream); ok {
+					if _, ok := streamMsg.Body.(*internal.Stream_Open); ok {
+						close(openPublished)
+					}
+				}
+				return err
+			}
+		})
+	})
+
+	sd := &info.ServiceDefinition{Name: "test", ID: "client"}
+	sd.RegisterMethod("stream", false, false, false, false)
+	c, err := NewRPCClientWithStreams(sd, b)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errChan := make(chan error, 1)
+	go func() {
+		_, err := OpenStream[*internal.Request, *internal.Response](
+			ctx, c, "stream", nil, psrpc.WithRequestTimeout(time.Minute),
+		)
+		errChan <- err
+	}()
+
+	select {
+	case <-openPublished:
+	case <-time.After(time.Second):
+		t.Fatal("stream open request was not published")
+	}
+	c.Close()
+
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, psrpc.ErrClientClosed)
+	case <-time.After(time.Second):
+		t.Fatal("stream open did not stop when the client closed")
+	}
+	require.Eventually(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.claimRequests) == 0 && len(c.streamChannels) == 0
+	}, time.Second, time.Millisecond)
+}
+
+func TestRequestSingleStopsWhenClientCloses(t *testing.T) {
+	sd := &info.ServiceDefinition{Name: "test", ID: "client"}
+	sd.RegisterMethod("rpc", false, false, false, false)
+	c, err := NewRPCClient(sd, bus.NewLocalMessageBus())
+	require.NoError(t, err)
+
+	errChan := make(chan error, 1)
+	go func() {
+		_, err := RequestSingle[*internal.Response](
+			context.Background(), c, "rpc", nil, &internal.Request{},
+			psrpc.WithRequestTimeout(time.Minute),
+		)
+		errChan <- err
+	}()
+
+	require.Eventually(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.responseChannels) == 1
+	}, time.Second, time.Millisecond)
+	c.Close()
+
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, psrpc.ErrClientClosed)
+	case <-time.After(time.Second):
+		t.Fatal("request did not stop when the client closed")
+	}
+}
+
+func TestRequestSingleStopsDuringServerSelectionWhenClientCloses(t *testing.T) {
+	sd := &info.ServiceDefinition{Name: "test", ID: "client"}
+	sd.RegisterMethod("rpc", true, false, true, false)
+	c, err := NewRPCClient(
+		sd,
+		bus.NewLocalMessageBus(),
+		psrpc.WithClientSelectTimeout(time.Minute),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errChan := make(chan error, 1)
+	go func() {
+		_, err := RequestSingle[*internal.Response](
+			ctx, c, "rpc", nil, &internal.Request{},
+			psrpc.WithRequestTimeout(time.Minute),
+		)
+		errChan <- err
+	}()
+
+	require.Eventually(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.claimRequests) == 1 && len(c.responseChannels) == 1
+	}, time.Second, time.Millisecond)
+	c.Close()
+
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, psrpc.ErrClientClosed)
+	case <-time.After(time.Second):
+		t.Fatal("server selection did not stop when the client closed")
+	}
+	require.Eventually(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.claimRequests) == 0 && len(c.responseChannels) == 0
+	}, time.Second, time.Millisecond)
+}
+
+func TestRequestMultiStopsWhenClientCloses(t *testing.T) {
+	sd := &info.ServiceDefinition{Name: "test", ID: "client"}
+	sd.RegisterMethod("multi", false, true, false, false)
+	c, err := NewRPCClient(sd, bus.NewLocalMessageBus())
+	require.NoError(t, err)
+
+	responses, err := RequestMulti[*internal.Response](
+		context.Background(), c, "multi", nil, &internal.Request{},
+		psrpc.WithRequestTimeout(time.Minute),
+	)
+	require.NoError(t, err)
+	c.Close()
+
+	select {
+	case _, ok := <-responses:
+		require.False(t, ok)
+	case <-time.After(time.Second):
+		t.Fatal("multi response channel did not close with the client")
+	}
+}
+
+func TestBlockedMultiResponseStopsWhenClientCloses(t *testing.T) {
+	const requestID = "blocked-response"
+	responseStarted := make(chan struct{})
+	internalResponses := make(chan *internal.Response, 1)
+	c := &RPCClient{
+		ClientOpts: psrpc.ClientOpts{
+			ResponseHooks: []psrpc.ClientResponseHook{
+				func(context.Context, proto.Message, psrpc.RPCInfo, proto.Message, error) {
+					close(responseStarted)
+				},
+			},
+		},
+		responseChannels: map[string]chan *internal.Response{requestID: internalResponses},
+	}
+	output := make(chan *psrpc.Response[*internal.Response])
+	m := &multiRPC[*internal.Response]{
+		c:         c,
+		i:         &info.RequestInfo{},
+		requestID: requestID,
+		resChan:   output,
+	}
+	m.handler = m
+
+	raw, err := bus.SerializePayload(&internal.Response{})
+	require.NoError(t, err)
+	internalResponses <- &internal.Response{RawResponse: raw}
+
+	go m.handleResponses(
+		context.Background(), &internal.Request{}, internalResponses,
+		psrpc.RequestOpts{Timeout: time.Minute},
+	)
+	<-responseStarted
+	c.Close()
+
+	if waitForResponseRouteRemoval(c, requestID, time.Second) {
+		return
+	}
+
+	// Release the old blocking send before failing so the test leaves no goroutine behind.
+	<-output
+	require.Eventually(t, func() bool {
+		return waitForResponseRouteRemoval(c, requestID, 0)
+	}, time.Second, time.Millisecond)
+	t.Fatal("blocked multi-RPC response did not stop when the client closed")
+}
+
+func waitForResponseRouteRemoval(c *RPCClient, requestID string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		c.mu.Lock()
+		_, ok := c.responseChannels[requestID]
+		c.mu.Unlock()
+		if !ok {
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/pkg/client/multi.go
+++ b/pkg/client/multi.go
@@ -123,6 +123,7 @@ func (m *multiRPC[ResponseType]) handleResponses(
 	opts psrpc.RequestOpts,
 ) {
 	timer := time.NewTimer(opts.Timeout)
+	defer timer.Stop()
 	for {
 		select {
 		case res := <-resChan:
@@ -151,14 +152,21 @@ func (m *multiRPC[ResponseType]) handleResponses(
 		case <-ctx.Done():
 			m.handler.Close()
 			return
+
+		case <-m.c.closed.Watch():
+			m.handler.Close()
+			return
 		}
 	}
 }
 
 func (m *multiRPC[ResponseType]) Recv(msg proto.Message, err error) {
-	m.resChan <- &psrpc.Response[ResponseType]{
+	select {
+	case m.resChan <- &psrpc.Response[ResponseType]{
 		Result: msg.(ResponseType),
 		Err:    err,
+	}:
+	case <-m.c.closed.Watch():
 	}
 }
 

--- a/pkg/client/rpc.go
+++ b/pkg/client/rpc.go
@@ -144,7 +144,7 @@ func newRPC[ResponseType proto.Message](c *RPCClient, i *info.RequestInfo) psrpc
 		var res *internal.Response
 
 		if i.RequireClaim {
-			sel, err := selectServer(ctx, claimChan, resChan, o.SelectionOpts, i.Queue)
+			sel, err := selectServerUntil(ctx, claimChan, resChan, o.SelectionOpts, i.Queue, c.closed.Watch())
 			if err != nil {
 				return nil, err
 			}
@@ -179,6 +179,10 @@ func newRPC[ResponseType proto.Message](c *RPCClient, i *info.RequestInfo) psrpc
 					err = psrpc.ErrRequestTimedOut
 				}
 				return
+
+			case <-c.closed.Watch():
+				err = psrpc.ErrClientClosed
+				return
 			}
 		}
 
@@ -210,6 +214,17 @@ func selectServer(
 	opts psrpc.SelectionOpts,
 	queue bool,
 ) (selection, error) {
+	return selectServerUntil(ctx, claimChan, resChan, opts, queue, nil)
+}
+
+func selectServerUntil(
+	ctx context.Context,
+	claimChan chan *internal.ClaimRequest,
+	resChan chan *internal.Response,
+	opts psrpc.SelectionOpts,
+	queue bool,
+	closed <-chan struct{},
+) (selection, error) {
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -229,6 +244,9 @@ func selectServer(
 
 	for {
 		select {
+		case <-closed:
+			return selection{}, psrpc.ErrClientClosed
+
 		case <-ctx.Done():
 			switch {
 			case opts.SelectionFunc != nil:

--- a/pkg/client/stream.go
+++ b/pkg/client/stream.go
@@ -37,6 +37,9 @@ func OpenStream[SendType, RecvType proto.Message](
 	topic []string,
 	opts ...psrpc.RequestOption,
 ) (psrpc.ClientStream[SendType, RecvType], error) {
+	if c.closed.IsBroken() {
+		return nil, psrpc.ErrClientClosed
+	}
 
 	i := c.GetInfo(rpc, topic)
 	o := getRequestOpts(ctx, i, c.ClientOpts, opts...)
@@ -96,7 +99,7 @@ func OpenStream[SendType, RecvType proto.Message](
 
 	if i.RequireClaim {
 		// nil resChan, so queue-ness is moot
-		sel, err := selectServer(ctx, claimChan, nil, o.SelectionOpts, false)
+		sel, err := selectServerUntil(ctx, claimChan, nil, o.SelectionOpts, false, c.closed.Watch())
 		if err != nil {
 			_ = cs.Close(err)
 			return nil, err
@@ -125,6 +128,10 @@ func OpenStream[SendType, RecvType proto.Message](
 		}
 		_ = cs.Close(err)
 		return nil, err
+
+	case <-c.closed.Watch():
+		_ = cs.Close(psrpc.ErrClientClosed)
+		return nil, psrpc.ErrClientClosed
 	}
 }
 


### PR DESCRIPTION
## Summary

`RPCClient.Close()` stopped the shared subscriptions, but pending RPC operations did not consistently observe the client shutdown.

Unary requests could remain blocked during server selection or response waits, stream opens could remain blocked during server selection or acknowledgement waits, and multi-RPC handlers could remain active until their caller context or request timeout ended.

## Changes

* Observe the client shutdown fuse at pending wait points and return `ErrClientClosed` when shutdown is selected.
* Stop in-flight stream opens while waiting for server selection or acknowledgement.
* Stop unary requests while waiting for server selection or a response.
* Stop multi-RPC handlers when the client closes.
* Allow blocked multi-RPC response delivery to stop on shutdown so the handler can remove its response route and close the caller-facing channel.

## Tests

Added deterministic lifecycle coverage for:

* opening a stream on an already closed client
* closing the client while a stream is waiting for acknowledgement
* closing the client while a unary request is waiting for a response
* closing the client during unary server selection
* closing the client while a multi-RPC is pending
* closing the client while multi-RPC response delivery is blocked
