### PR TITLE
bus/natsbus: avoid closing the direct NATS callback channel

### DIFF
--- a/internal/bus/bus_nats.go
+++ b/internal/bus/bus_nats.go
@@ -164,18 +164,19 @@ func (n *natsSubscription) write(msg *nats.Msg) {
 }
 
 func (n *natsSubscription) read() ([]byte, bool) {
-	msg, ok := <-n.msgChan
-	if !ok {
+	select {
+	case msg := <-n.msgChan:
+		return msg.Data, true
+	case <-n.ctx.Done():
 		return nil, false
 	}
-	return msg.Data, true
 }
 
 func (n *natsSubscription) Close() error {
+	// Unsubscribe does not wait for an in-flight NATS callback. Keep msgChan
+	// open and use cancellation to unblock both read and write.
 	n.cancel()
-	err := n.sub.Unsubscribe()
-	close(n.msgChan)
-	return err
+	return n.sub.Unsubscribe()
 }
 
 type natsRouter struct {

--- a/internal/bus/bus_nats_test.go
+++ b/internal/bus/bus_nats_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bus
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/ory/dockertest/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/psrpc/internal"
+)
+
+func TestNATSSubscriptionReadCancellation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		s := &natsSubscription{ctx: ctx, msgChan: make(chan *nats.Msg)}
+		returned := make(chan bool, 1)
+		go func() {
+			_, ok := s.read()
+			returned <- ok
+		}()
+		synctest.Wait() // The reader is blocked before cancellation.
+		cancel()
+		synctest.Wait()
+		select {
+		case ok := <-returned:
+			require.False(t, ok)
+		default:
+			// Release the old implementation's reader before failing.
+			close(s.msgChan)
+			<-returned
+			t.Fatal("read remained blocked after cancellation")
+		}
+	})
+}
+
+func TestNATSSubscriptionWriteCancellation(t *testing.T) {
+	for _, size := range []int{0, 1} {
+		t.Run(fmt.Sprint(size), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				s := &natsSubscription{ctx: ctx, msgChan: make(chan *nats.Msg, size)}
+				if size > 0 {
+					s.msgChan <- &nats.Msg{}
+				}
+				done := make(chan struct{})
+				go func() {
+					s.write(&nats.Msg{})
+					close(done)
+				}()
+				synctest.Wait() // The callback is blocked on the full channel.
+				cancel()
+				synctest.Wait()
+				select {
+				case <-done:
+				default:
+					t.Fatal("write remained blocked after cancellation")
+				}
+			})
+		})
+	}
+}
+
+func TestNATSSubscriptionClose(t *testing.T) {
+	ctx := context.Background()
+	pool, err := dockertest.NewPool(ctx, "")
+	require.NoError(t, err)
+	server, err := pool.Run(ctx, "nats", dockertest.WithTag("latest"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, server.Close(ctx)) })
+	var nc *nats.Conn
+	require.NoError(t, pool.Retry(ctx, 0, func() error {
+		var err error
+		nc, err = nats.Connect("nats://"+server.GetHostPort("4222/tcp"), nats.NoReconnect())
+		return err
+	}))
+	t.Cleanup(nc.Close)
+
+	for _, tc := range []struct {
+		name string
+		size int
+		full bool
+	}{
+		{name: "unbuffered"},
+		{name: "buffered", size: 1},
+		{name: "full", size: 1, full: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			s := &natsSubscription{ctx: ctx, cancel: cancel, msgChan: make(chan *nats.Msg, tc.size)}
+			if tc.full {
+				s.msgChan <- &nats.Msg{}
+			}
+			entered := make(chan struct{})
+			resume := make(chan struct{})
+			exited := make(chan struct{})
+			release := sync.OnceFunc(func() { close(resume) })
+			write := false // Published to the callback by closing resume.
+			var err error
+			s.sub, err = nc.Subscribe(tc.name, func(m *nats.Msg) {
+				close(entered)
+				<-resume
+				if write {
+					s.write(m)
+				}
+			})
+			require.NoError(t, err)
+			s.sub.SetClosedHandler(func(string) { close(exited) })
+			t.Cleanup(func() {
+				cancel()
+				_ = s.sub.Unsubscribe()
+				release()
+				select {
+				case <-exited:
+				case <-time.After(5 * time.Second):
+					t.Error("NATS callback did not exit")
+				}
+			})
+			require.NoError(t, nc.Publish(tc.name, []byte("late")))
+			select {
+			case <-entered:
+			case <-time.After(5 * time.Second):
+				t.Fatal("NATS callback did not start")
+			}
+
+			closed := make(chan error, 1)
+			go func() { closed <- s.Close() }()
+			select {
+			case err := <-closed:
+				require.NoError(t, err)
+			case <-time.After(5 * time.Second):
+				t.Fatal("Close waited for the paused callback")
+			}
+			require.False(t, s.sub.IsValid())
+
+			// NATS has entered its callback but has not called write yet.
+			// Assert the ownership invariant directly: choosing between a
+			// canceled context and a closed-channel send would be random.
+			if tc.full {
+				<-s.msgChan
+			}
+			select {
+			case _, ok := <-s.msgChan:
+				require.True(t, ok, "Close closed the channel while a NATS callback can still write")
+				t.Fatal("unexpected message from the paused callback")
+			default:
+			}
+			if tc.full {
+				s.msgChan <- &nats.Msg{}
+			}
+			write = true
+			release()
+			select {
+			case <-exited:
+			case <-time.After(5 * time.Second):
+				t.Fatal("late callback did not exit after Close")
+			}
+		})
+	}
+
+	t.Run("typed reader", func(t *testing.T) {
+		raw, err := NewNatsMessageBus(nc).Subscribe(ctx, Channel{Server: "typed"}, 0)
+		require.NoError(t, err)
+		s := newSubscription[*internal.Request](raw, 0, 0)
+		closed := make(chan error, 1)
+		go func() { closed <- s.Close() }()
+		select {
+		case err := <-closed:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("typed Close did not release the raw reader")
+		}
+		select {
+		case _, ok := <-s.Channel():
+			require.False(t, ok)
+		default:
+			t.Fatal("typed output was not closed before Close returned")
+		}
+	})
+
+	t.Run("churn", func(t *testing.T) {
+		b := NewNatsMessageBus(nc).(*natsMessageBus)
+		for i := range 100 {
+			subject := fmt.Sprintf("churn.%d", i)
+			s, err := b.subscribe(ctx, subject, i%2, i%4 < 2)
+			require.NoError(t, err)
+			exited := make(chan struct{})
+			s.sub.SetClosedHandler(func(string) { close(exited) })
+			for range 8 {
+				require.NoError(t, nc.Publish(subject, []byte("message")))
+			}
+			require.NoError(t, nc.FlushTimeout(5*time.Second))
+			require.NoError(t, s.Close())
+			select {
+			case <-exited:
+			case <-time.After(5 * time.Second):
+				t.Fatal("NATS callback did not exit during subscription churn")
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

NATS `Unsubscribe` removes a subscription but does not wait for an asynchronous callback that has already been selected. Direct PSRPC subscriptions currently close their handoff channel immediately afterward, so a late callback can race with the close and panic with `send on closed channel`.

Keep the direct callback channel open and make the raw reader observe context cancellation, matching the existing writer behavior.

Routed subscriptions are unchanged because `router.mu` already orders child writes, route removal, and channel closure.

## Root cause

The following sequence is possible:

1. NATS selects a pending message for an asynchronous subscription and observes that the subscription is still open.
2. `subscription.Close` cancels the context and calls `Unsubscribe`.
3. `Unsubscribe` removes the subscription and returns without joining the selected callback.
4. `Close` closes `msgChan`.
5. The callback resumes and attempts to send to `msgChan`, causing `panic: send on closed channel`.

Cancellation alone does not make closing the channel safe. If the canceled-context receive and a send to a closed channel are both selectable, Go may choose the send and panic.

## Fix

- Do not close the direct NATS callback channel.
- Let both `read` and `write` terminate through context cancellation.
- Preserve the existing routed-subscription shutdown behavior.

The resulting ownership invariant is:

> While a NATS callback can still reference a direct subscription, its send destination remains open.

Typed `Subscription.Close` still waits for its forwarding goroutine to exit and closes the typed output channel before returning.

## Tests

The regression test uses a real NATS asynchronous callback and pauses it immediately before the production `write` call. It then:

1. Calls `Close` and verifies that it returns without waiting for the paused callback.
2. Confirms that the NATS subscription has been removed.
3. Verifies that the callback destination remains open.
4. Resumes the callback and waits for NATS callback-loop completion.

This deterministically checks the unsafe ownership boundary without relying on scheduler timing or randomly selecting the panic arm.

Additional coverage includes:

- canceled raw readers;
- blocked writers with unbuffered and full channels;
- empty and full buffered callback channels;
- direct and queue subscription churn.

## Verification

The following passed:

- `go test ./pkg/bus/natsbus -count=1`
- `go test -race ./pkg/bus/natsbus -count=1`
- `go tool mage testall`
- `go test -race ./... -count=1`
- focused NATS lifecycle and transport tests under `-race -count=10`

The repeated focused run covered 1,000 churn subscriptions. The unpatched implementation produced both a race-detector report and an actual `send on closed channel` panic.

## Behavior notes

This is cancellation-based shutdown, not a drain or callback join. A callback selected before `Unsubscribe` may still enqueue a bounded buffered message if the send is ready. Owners must also continue calling `Close`; canceling the parent context alone does not unregister the NATS subscription.
